### PR TITLE
core: add manifest used for krew-index

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,18 +38,27 @@ jobs:
     - name: wait for operator pod to be ready
       run: tests/github-action-helper.sh wait_for_pod_to_be_ready_state
 
+    - name: install krew
+      run: tests/github-action-helper.sh install_krew
+
+    - name: download tool zip file
+      run: |
+        curl -OJL https://github.com/rook/kubectl-rook-ceph/archive/v0.0.1.zip
+        export PATH="${PATH}:${HOME}/.krew/bin"
+        kubectl krew install --manifest=rook-ceph.yaml --archive=kubectl-rook-ceph-0.0.1.zip
+
     - name: Test pluging with ceph commands
       run: |
-        # when we have the kubectl krew plugin available we can use like `kubectl rook-ceph` but for now in local deployment we have to use `kubectl rook_ceph` as kubectl plugin has this limitation.
-        # Doc link to clear the comment above:
-          # https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
-          # https://kubernetes.io/docs/tasks/extend-kubectl/kubectl-plugins/#naming-a-plugin
-          # https://krew.sigs.k8s.io/docs/developer-guide/distributing-with-krew/
-        sudo install kubectl-rook-ceph.sh /usr/local/bin/kubectl-rook_ceph
-        # run ceph commands with the plugin
-        kubectl rook_ceph ceph status
-        kubectl rook_ceph ceph status -f json
-        kubectl rook_ceph ceph status --format json-pretty
-        kubectl rook_ceph ceph mon dump
-        kubectl rook_ceph ceph mon stat
-        kubectl rook_ceph ceph osd tree
+        export PATH="${PATH}:${HOME}/.krew/bin"
+        # run ceph commands with the krew plugin
+        kubectl rook-ceph ceph status
+        kubectl rook-ceph ceph status -f json
+        kubectl rook-ceph ceph status --format json-pretty
+        kubectl rook-ceph ceph mon dump
+        kubectl rook-ceph ceph mon stat
+        kubectl rook-ceph ceph osd tree
+
+    - name: setup tmate session
+      if: failure()
+      uses: mxschmitt/action-tmate@v3
+      timeout-minutes: 180

--- a/README.md
+++ b/README.md
@@ -6,16 +6,21 @@ Provide common management and troubleshooting tools for the Rook Ceph storage pr
 
 ## Install
 
-To install tool without krew
+To install tool
 
-1. Download the [kubectl-rook-ceph.sh](kubectl-rook-ceph.sh)
-2. ```sudo install kubectl-rook-ceph.sh /usr/local/bin/kubectl-rook_ceph```
+1. Download the release zip file
+
+    ```curl -OJL https://github.com/rook/kubectl-rook-ceph/archive/v0.0.1.zip```
+
+2. Run the command below to use it with krew (this step is temporary until we push our manifest to krew-index)
+
+    ```$ kubectl krew install --manifest=rook-ceph.yaml --archive=<PATH_TO_ZIP_FILE>```
 
 Now, use the tool with `kubectl`
 
 ```console
-# example: `kubectl rook_ceph` as prefix with `ceph` command
-kubectl rook_ceph ceph status
+# example: `kubectl rook-ceph` as prefix with `ceph` command
+kubectl rook-ceph ceph status
 ```
 
 

--- a/rook-ceph.yaml
+++ b/rook-ceph.yaml
@@ -1,0 +1,27 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: rook-ceph
+spec:
+  version: "v0.0.1"
+  homepage: https://github.com/rook/kubectl-rook-ceph
+  shortDescription: "Rook plugin for Ceph management"
+  description: |
+     Krew plugin to provide insight to Rook configuration of the Ceph storage provider.
+  platforms:
+  - selector:
+      matchExpressions:
+      - key: "os"
+        operator: "In"
+        values:
+        - darwin
+        - linux
+        - windows
+    uri: https://github.com/rook/kubectl-rook-ceph/archive/v0.0.1.zip
+    sha256: 2ca817372441097235c0b7e8dff87c0e99153b154dc83a6a47fc5d691a966209
+    files:
+    - from: "kubectl-rook-ceph-0.0.1/kubectl-rook-ceph.sh"
+      to: "kubect-rook-ceph.sh"
+    - from: "kubectl-rook-ceph-0.0.1/LICENSE"
+      to: "."
+    bin: kubect-rook-ceph.sh

--- a/tests/github-action-helper.sh
+++ b/tests/github-action-helper.sh
@@ -2,31 +2,56 @@
 
 set -eEuo pipefail
 
+: "${FUNCTION:=${1}}"
+
+# source https://krew.sigs.k8s.io/docs/user-guide/setup/install/
+install_krew() {
+  cd "$(mktemp -d)"
+  OS="$(uname | tr '[:upper:]' '[:lower:]')"
+  ARCH="$(uname -m | sed -e 's/x86_64/amd64/' -e 's/\(arm\)\(64\)\?.*/\1\2/' -e 's/aarch64$/arm64/')"
+  curl -fsSLO "https://github.com/kubernetes-sigs/krew/releases/latest/download/krew.tar.gz"
+  tar zxvf krew.tar.gz
+  KREW=./krew-"${OS}_${ARCH}"
+  "$KREW" install krew
+  cp "$HOME"/.krew/bin/kubectl-krew /usr/local/bin/
+}
+
 # source https://github.com/rook/rook
 use_local_disk() {
-    sudo swapoff --all --verbose
-    sudo umount /mnt
-    # search for the device since it keeps changing between sda and sdb
-    sudo wipefs --all --force /dev/$(lsblk|awk '/14G/ {print $1}'| head -1)1
-    sudo lsblk
+  sudo swapoff --all --verbose
+  sudo umount /mnt
+  # search for the device since it keeps changing between sda and sdb
+  sudo wipefs --all --force /dev/"$(lsblk|awk '/14G/ {print $1}'| head -1)"1
+  sudo lsblk
 }
 
 deploy_rook() {
-    kubectl create -f https://raw.githubusercontent.com/rook/rook/master/cluster/examples/kubernetes/ceph/common.yaml
-    kubectl create -f https://raw.githubusercontent.com/rook/rook/master/cluster/examples/kubernetes/ceph/crds.yaml
-    kubectl create -f https://raw.githubusercontent.com/rook/rook/master/cluster/examples/kubernetes/ceph/operator.yaml
-    curl https://raw.githubusercontent.com/rook/rook/master/cluster/examples/kubernetes/ceph/cluster-test.yaml -o cluster-test.yaml
-    sed -i "s|#deviceFilter:|deviceFilter: $(lsblk|awk '/14G/ {print $1}'| head -1)|g" cluster-test.yaml
-    kubectl create -f cluster-test.yaml
+  kubectl create -f https://raw.githubusercontent.com/rook/rook/master/cluster/examples/kubernetes/ceph/common.yaml
+  kubectl create -f https://raw.githubusercontent.com/rook/rook/master/cluster/examples/kubernetes/ceph/crds.yaml
+  kubectl create -f https://raw.githubusercontent.com/rook/rook/master/cluster/examples/kubernetes/ceph/operator.yaml
+  curl https://raw.githubusercontent.com/rook/rook/master/cluster/examples/kubernetes/ceph/cluster-test.yaml -o cluster-test.yaml
+  sed -i "s|#deviceFilter:|deviceFilter: $(lsblk|awk '/14G/ {print $1}'| head -1)|g" cluster-test.yaml
+  kubectl create -f cluster-test.yaml
 }
 
 # wait_for_pod_to_be_ready_state check for operator pod to in ready state
 wait_for_pod_to_be_ready_state() {
-  timeout 20 bash <<-'EOF'
-    until [ $(kubectl get pod -l app=rook-ceph-operator -n rook-ceph -o jsonpath='{.items[*].metadata.name}' -o custom-columns=READY:status.containerStatuses[*].ready | grep -c true) -eq 1 ]; do
+  timeout 200 bash <<-'EOF'
+    until [ $(kubectl get pod -l app=rook-ceph-osd -n rook-ceph -o jsonpath='{.items[*].metadata.name}' -o custom-columns=READY:status.containerStatuses[*].ready | grep -c true) -eq 1 ]; do
       echo "waiting for the pods to be in ready state"
       sleep 1
     done
 EOF
-
 }
+
+########
+# MAIN #
+########
+
+FUNCTION="$1"
+shift # remove function arg now that we've recorded it
+# call the function with the remainder of the user-provided args
+if ! $FUNCTION "$@"; then
+  echo "Call to $FUNCTION was not successful" >&2
+  exit 1
+fi


### PR DESCRIPTION
Adding manifest file that will be used to
krew-index and also we can test locally with this
manifest file. Also, updating readme and CI accordingly.

Signed-off-by: subhamkrai <srai@redhat.com>