### PR TITLE
docs: update the Readme doc to add commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,27 +2,74 @@
 
 # kubectl-rook-ceph
 
-Provide common management and troubleshooting tools for the Rook Ceph storage provider as a Krew plugin.
+Provide common management and troubleshooting tools for the [Rook Ceph](https://github.com/rook/rook) storage provider as a [Krew](https://github.com/kubernetes-sigs/krew) plugin.
 
 ## Install
 
-To install tool
+To install the plugin, run:
 
-1. Run the command below to use it with krew
+  ```kubectl krew install rook-ceph```
 
-    ```kubectl krew install rook-ceph```
+## Usage
 
-Now, use the tool with `kubectl`
+`kubectl rook-ceph <root-args> <command> <command-args>`
+
+### Root args
+
+- `--namespace` | `-n`: the Kubernetes namespace in which the CephCluster resides (default: rook-ceph)
+- `--help` | `-h`: Output help text
+
+### Commands
+
+- `ceph`: Run a Ceph CLI command. Supports any arguments the `ceph` command supports. See [Ceph docs](https://docs.ceph.com/en/pacific/start/intro/) for more.
+
+- `operator`: run sub-commands against the Rook-Ceph operator
+  -  `restart`: restart the Rook-Ceph operator
+
+- `help`: Output help text
+
+
+## Examples
+
+### Run a Ceph Command
+
+Any `ceph` command can be run with the plugin. This example gets the ceph status:
 
 ```console
-# example: `kubectl rook-ceph` as prefix with `ceph` command
 kubectl rook-ceph ceph status
 ```
 
+>```text
+>  cluster:
+>    id:     a1ac6554-4cc8-4c3b-a8a3-f17f5ec6f529
+>    health: HEALTH_OK
+>
+>  services:
+>    mon: 3 daemons, quorum a,b,c (age 11m)
+>    mgr: a(active, since 10m)
+>    mds: 1/1 daemons up, 1 hot standby
+>    osd: 3 osds: 3 up (since 10m), 3 in (since 8d)
+>
+>  data:
+>    volumes: 1/1 healthy
+>    pools:   6 pools, 137 pgs
+>    objects: 34 objects, 4.1 KiB
+>    usage:   58 MiB used, 59 GiB / 59 GiB avail
+>    pgs:     137 active+clean
+>
+>  io:
+>    client:   1.2 KiB/s rd, 2 op/s rd, 0 op/s wr
+>```
 
-## Commands
+### Restart the Operator
 
-TBD
+```console
+kubectl rook-ceph operator restart
+```
+
+>```text
+>deployment.apps/rook-ceph-operator restarted
+>```
 
 ## Contributing
 


### PR DESCRIPTION
Unfortunately, we forgot to add the list of commands
we should have with our plugin. This commit updates
the doc to add commands this plugin supports.
Like, running any ceph command and restart operator.

Signed-off-by: subhamkrai <srai@redhat.com>