### PR TITLE
action: add github action to release plugin at krew index

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,19 @@
+name: Release Plugin
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  Release-Plugin-At-Krew-Index:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      # krew-release-bot is a bot that automates the update of plugin manifests in krew-index when a new version of your kubectl plugin is released.
+      # https://github.com/rajatjindal/krew-release-bot
+      - name: Update new version in krew-index
+        uses: rajatjindal/krew-release-bot@v0.0.40

--- a/.krew.yaml
+++ b/.krew.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: rook-ceph
 spec:
-  version: "v0.0.1"
+  version: "{{ .TagName }}"
   homepage: https://github.com/rook/kubectl-rook-ceph
   shortDescription: "Rook plugin for Ceph management"
   description: |
@@ -17,11 +17,10 @@ spec:
         - darwin
         - linux
         - windows
-    uri: https://github.com/rook/kubectl-rook-ceph/archive/v0.0.1.zip
-    sha256: 2ca817372441097235c0b7e8dff87c0e99153b154dc83a6a47fc5d691a966209
+    {{addURIAndSha "https://github.com/rook/kubectl-rook-ceph/archive/{{ .TagName }}.zip" .TagName }}
     files:
-    - from: "kubectl-rook-ceph-0.0.1/kubectl-rook-ceph.sh"
+    - from: "kubectl-rook-ceph-*/kubectl-rook-ceph.sh"
       to: "kubect-rook-ceph.sh"
-    - from: "kubectl-rook-ceph-0.0.1/LICENSE"
+    - from: "kubectl-rook-ceph-*/LICENSE"
       to: "."
     bin: kubect-rook-ceph.sh


### PR DESCRIPTION
Changing plugin manifest with template which will be used
for github action to automates the update of plugin manifests
in krew-index when a new version of plugin is released.

see https://github.com/rajatjindal/krew-release-bot#readme for
more details.

Signed-off-by: subhamkrai <srai@redhat.com>