### PR TITLE
core: support operator and cluster in different namespaces

### DIFF
--- a/.github/workflows/ci-for-default-ns.yaml
+++ b/.github/workflows/ci-for-default-ns.yaml
@@ -1,4 +1,4 @@
-name: kubectl plugin test
+name: Plugin test
 on:
   pull_request:
 
@@ -8,7 +8,7 @@ defaults:
     shell: bash --noprofile --norc -eo pipefail -x {0}
 
 jobs:
-  test-with-plugin:
+  with-krew:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
@@ -35,7 +35,7 @@ jobs:
 
   # This test is required to test latest changes or the changes that not present
   # with current version of rook-ceph krew plugin
-  test-with-pr-changes:
+  with-pr-changes-in-default-namespace:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
@@ -60,7 +60,7 @@ jobs:
           kubectl rook_ceph operator restart
 
           # let's wait for operator pod to be restart
-          tests/github-action-helper.sh wait_for_operator_pod_to_be_ready_state
+          tests/github-action-helper.sh wait_for_operator_pod_to_be_ready_state_default
           kubectl rook_ceph operator set ROOK_LOG_LEVEL DEBUG
           kubectl rook_ceph mons
           kubectl rook_ceph rook version

--- a/.github/workflows/ci-for-diff-ns.yaml
+++ b/.github/workflows/ci-for-diff-ns.yaml
@@ -1,0 +1,50 @@
+name: Plugin test
+on:
+  pull_request:
+
+defaults:
+  run:
+    # reference: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#using-a-specific-shell
+    shell: bash --noprofile --norc -eo pipefail -x {0}
+
+jobs:
+  # This test is required to test latest changes or the changes that not present
+  # with current version of rook-ceph krew plugin
+  with-pr-changes-in-custom-namespace:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: setup cluster
+        uses: ./.github/workflows/cluster-setup
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          op-ns: "test-operator"
+          cluster-ns: "test-cluster"
+
+      - name: install script
+        run: sudo install kubectl-rook-ceph.sh /usr/local/bin/kubectl-rook_ceph
+
+      - name: Test Plugin
+        run: |
+          kubectl rook_ceph -o test-operator -n test-cluster ceph status
+          kubectl rook_ceph -o test-operator -n test-cluster ceph status -f json
+          kubectl rook_ceph -o test-operator -n test-cluster ceph status --format json-pretty
+          kubectl rook_ceph -o test-operator -n test-cluster rbd ls replicapool
+          kubectl rook_ceph -o test-operator -n test-cluster operator restart
+
+          # let's wait for operator pod to be restart
+          tests/github-action-helper.sh wait_for_operator_pod_to_be_ready_state_custom
+          kubectl rook_ceph -o test-operator -n test-cluster operator set ROOK_LOG_LEVEL DEBUG
+          kubectl rook_ceph -o test-operator -n test-cluster mons
+          kubectl rook_ceph -o test-operator -n test-cluster rook version
+          kubectl rook_ceph -o test-operator -n test-cluster rook status
+          kubectl rook_ceph -o test-operator -n test-cluster rook status all
+          kubectl rook_ceph -o test-operator -n test-cluster rook status cephobjectstores
+
+      - name: setup tmate session for debugging when event is PR
+        if: failure() && github.event_name == 'pull_request'
+        uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,3 +67,7 @@ jobs:
           kubectl rook_ceph rook status
           kubectl rook_ceph rook status all
           kubectl rook_ceph rook status cephobjectstores
+
+      - name: setup tmate session for debugging when event is PR
+        if: failure() && github.event_name == 'pull_request'
+        uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/cluster-setup/action.yaml
+++ b/.github/workflows/cluster-setup/action.yaml
@@ -4,6 +4,12 @@ inputs:
   github-token:
     description: GITHUB_TOKEN from the calling workflow
     required: true
+  op-ns:
+    description: operator namespace where rook operator will deploy
+    required: false
+  cluster-ns:
+    description: cluster namespace where ceph cluster will deploy
+    required: false
 
 runs:
   using: "composite"
@@ -11,14 +17,14 @@ runs:
     - name: setup minikube
       uses: manusa/actions-setup-minikube@v2.4.2
       with:
-        minikube version: 'v1.23.2'
-        kubernetes version: 'v1.22.2'
+        minikube version: "v1.23.2"
+        kubernetes version: "v1.22.2"
         start args: --memory 6g --cpus=2
         github token: ${{ inputs.github-token }}
 
     - name: print k8s cluster status
       shell: bash --noprofile --norc -eo pipefail -x {0}
-      run:  |
+      run: |
         minikube status
         kubectl get nodes
 
@@ -28,8 +34,10 @@ runs:
 
     - name: deploy rook cluster
       shell: bash --noprofile --norc -eo pipefail -x {0}
+      if: inputs.op-ns == '' || inputs.cluster-ns == ''
       run: tests/github-action-helper.sh deploy_rook
 
-    - name: wait for operator pod to be ready
+    - name: deploy rook cluster in cutom namespace
       shell: bash --noprofile --norc -eo pipefail -x {0}
-      run: tests/github-action-helper.sh wait_for_pod_to_be_ready_state
+      if: inputs.op-ns != '' || inputs.cluster-ns != ''
+      run: tests/github-action-helper.sh deploy_rook_in_custom_namespace ${{ inputs.op-ns }} ${{ inputs.cluster-ns }}

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ To install the plugin, run:
 ### Root args
 
 - `--namespace` | `-n`: the Kubernetes namespace in which the CephCluster resides (default: rook-ceph)
+- `--operator-namespace` | `-o`: the Kubernetes namespace in which the rook operator resides (default: rook-ceph)
 - `--help` | `-h`: Output help text
 
 ### Commands

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ go: go1.16.13
 ### Ceph Versions
 
 ```console
-kubectl rook_ceph ceph versions
+kubectl rook-ceph ceph versions
 ```
 
 ```text


### PR DESCRIPTION
currently, the tool can't handle different namespace for operator and
cluster.

With this path, we'll have two namespaces
1. `--namespace` | `-n`: namespace of CephCluster (default: rook-ceph):
   it will first read from CLI arg, if not passed then it will read from
   env var `ROOK_CLUSTER_NAMESPACE` if that's empty  default to `rook-ceph`.

2. `--operator-namespace` | `-op-ns`: namespace of rook operator
   (default: <namespace> i.e rook-ceph). it will first read from cli arg,
   if not passed then it will read from env var `ROOK_OPERATOR_NAMESPACE`
   if that's empty default to <namespace>(the one in first step) i.e
   `rook-ceph`.

Closes: https://github.com/rook/kubectl-rook-ceph/issues/25
Signed-off-by: subhamkrai <srai@redhat.com>