### PR TITLE
core: add health command to print cluster health

### DIFF
--- a/.github/workflows/ci-for-default-ns.yaml
+++ b/.github/workflows/ci-for-default-ns.yaml
@@ -77,6 +77,7 @@ jobs:
           # we need to sleep so the osd will be marked down before purging the osd
           sleep 5
           kubectl-rook_ceph rook purge-osd 0 --force
+          kubectl rook_ceph health
       - name: setup tmate session for debugging when event is PR
         if: failure() && github.event_name == 'pull_request'
         uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/ci-for-diff-ns.yaml
+++ b/.github/workflows/ci-for-diff-ns.yaml
@@ -54,6 +54,7 @@ jobs:
           # we need to sleep so the osd will be marked down before purging the osd
           sleep 5
           kubectl-rook_ceph -o test-operator -n test-cluster rook purge-osd 0 --force
+          kubectl rook_ceph -o test-operator -n test-cluster health
 
       - name: setup tmate session for debugging when event is PR
         if: failure() && github.event_name == 'pull_request'

--- a/README.md
+++ b/README.md
@@ -25,20 +25,22 @@ To install the plugin, run:
 
 - `ceph <args>` : Run a Ceph CLI command. Supports any arguments the `ceph` command supports. See [Ceph docs](https://docs.ceph.com/en/pacific/start/intro/) for more.
 
-- `rbd <args>` : Call a 'rbd' CLI command with arbitrary args"
+- `rbd <args>` : Call a 'rbd' CLI command with arbitrary args
 
-- `mons` : Print mon endpoints"
+- `mons` : Print mon endpoints
+
+- `health` : check health of the cluster and common configuration issues
 
 - `operator`
   - `restart` : Restart the Rook-Ceph operator
   - `set <property> <value>` : Set the property in the rook-ceph-operator-config configmap.
 
 - `rook`
-  - `version`     : Print the version of Rook"
-  - `status`      : Print the phase and/or conditions of every CR in the namespace"
+  - `version`     : Print the version of Rook
+  - `status`      : Print the phase and/or conditions of every CR in the namespace
   - `status all`  : Print the phase and conditions of all CRs
   - `status <CR>` : Print the phase and conditions of CRs of a specific type, such as `cephobjectstore`, `cephfilesystem`, etc
-  - `purge-osd <osd-id> [--force]` : Permanently remove an OSD from the cluster. Multiple OSDs can be removed with a comma-separated list of IDs."
+  - `purge-osd <osd-id> [--force]` : Permanently remove an OSD from the cluster. Multiple OSDs can be removed with a comma-separated list of IDs.
 
 - `help` : Output help text
 

--- a/kubectl-rook-ceph.sh
+++ b/kubectl-rook-ceph.sh
@@ -35,6 +35,7 @@ function print_usage() {
   echo "COMMANDS"
   echo "  ceph <args>                               : call a 'ceph' CLI command with arbitrary args"
   echo "  rbd <args>                                : call a 'rbd' CLI command with arbitrary args"
+  echo "  health                                    : check health of the cluster and common configuration issues"
   echo "  operator <subcommand>..."
   echo "    restart                                 : restart the Rook-Ceph operator"
   echo "    set <property> <value>                  : Set the property in the rook-ceph-operator-config configmap."
@@ -50,7 +51,7 @@ function print_usage() {
 
 function fail_error() {
   print_usage >&2
-  echo "ERROR: $*" >&2
+  error_msg " $*" >&2
   exit 1
 }
 
@@ -149,6 +150,18 @@ function end_of_command_parsing() {
   fi
 }
 
+function info_msg() {
+  echo -e "${INFO_PREFIX}" "$@"
+}
+
+function warn_msg() {
+  echo -e "${WARNING_PREFIX}" "$@"
+}
+
+function error_msg() {
+  echo -e "${ERROR_PREFIX}" "$@"
+}
+
 # run a kubectl command in the operator namespace
 function KUBECTL_NS_OPERATOR() {
   $TOP_LEVEL_COMMAND --namespace "$ROOK_OPERATOR_NAMESPACE" "$@"
@@ -219,7 +232,7 @@ function fetch_mon_endpoints() {
 ####################################################################################################
 
 function rook_version() {
-  [[ -z "${1:-""}" ]] && fail_error "Missing 'version' subcommand"
+  [[ -z "${1:-""}" ]] && fail_error "Missing subcommand"
   subcommand="$1"
   shift # remove the subcommand from the front of the arg list
   case "$subcommand" in
@@ -246,9 +259,9 @@ function run_rook_version() {
 function run_rook_cr_status() {
   if [ "$#" -eq 1 ] && [ "$1" = "all" ]; then
     cr_list=$(KUBECTL_NS_CLUSTER get crd | awk '{print $1}' | sed '1d')
-    echo "CR status"
+    info_msg " CR status"
     for cr in $cr_list; do
-      echo "$cr": "$(KUBECTL_NS_CLUSTER get "$cr" -ojson | jq --monochrome-output '.items[].status')"
+      echo -e "$cr": "$(KUBECTL_NS_CLUSTER get "$cr" -ojson | jq --monochrome-output '.items[].status')"
     done
   elif [[ "$#" -eq 1 ]]; then
     KUBECTL_NS_CLUSTER get "$1" -ojson | jq --monochrome-output '.items[].status'
@@ -271,6 +284,90 @@ function run_purge_osd() {
       ROOK_CEPH_SECRET=$ceph_secret \
       ROOK_CONFIG_DIR=/var/lib/rook && \
     rook ceph osd remove --osd-ids=$1 --force-osd-removal=$force_removal"
+}
+
+function run_cluster_health() {
+  end_of_command_parsing "$@" # end of command tree
+  set +e                      # if there are no pod that are not running, then do no exit
+  check_mon_pods_nodes
+  echo
+  check_mon_quorum
+  echo
+  check_osd_pod_count_and_nodes
+  echo
+  check_all_pods_status
+  echo
+  check_pg_are_active_clean
+  echo
+  check_mgr_pods_status_and_count
+  set -e
+}
+
+function check_mon_pods_nodes() {
+  info_msg " Checking if at least three mon pods are running on different nodes"
+  mon_unique_node_count=$(KUBECTL_NS_CLUSTER get pod | grep mon | grep -v canary | awk '{print $2}' | sort | uniq | wc -l)
+  if [ "$mon_unique_node_count" -lt 3 ]; then
+    warn_msg " At least three mon pods should running on different nodes"
+  fi
+  KUBECTL_NS_CLUSTER get pod | grep mon | grep --invert-match canary
+}
+
+function check_mon_quorum() {
+  info_msg " Checking mon quorum and ceph health details"
+  ceph_health_details=$(KUBECTL_NS_OPERATOR exec deploy/rook-ceph-operator -- ceph health detail --conf="$CEPH_CONF_PATH")
+  if [[ "$ceph_health_details" = "HEALTH_OK" ]]; then
+    echo -e "$ceph_health_details"
+  elif [[ "$ceph_health_details" =~ "HEALTH_WARN" ]]; then
+    warn_msg " $ceph_health_details"
+  elif [[ "$ceph_health_details" =~ "HEALTH_ERR" ]]; then
+    error_msg " $ceph_health_details"
+  fi
+}
+
+function check_osd_pod_count_and_nodes() {
+  info_msg " Checking if at least three osd pods are running on different nodes"
+  osd_unique_node_count=$(KUBECTL_NS_CLUSTER get pod | grep osd | grep -v prepare | awk '{print $2}' | sort | uniq | wc -l)
+  if [ "$osd_unique_node_count" -lt 3 ]; then
+    warn_msg " At least three osd pods should running on different nodes"
+  fi
+  KUBECTL_NS_CLUSTER get pod | grep osd | grep --invert-match prepare
+}
+
+function check_all_pods_status() {
+  info_msg " Pods that are in 'Running' status"
+  KUBECTL_NS_OPERATOR get pod --field-selector status.phase=Running
+  if [ "$ROOK_OPERATOR_NAMESPACE" != "$ROOK_CLUSTER_NAMESPACE" ]; then
+    KUBECTL_NS_CLUSTER get pod --field-selector status.phase=Running
+  fi
+
+  echo
+  warn_msg " Pods that are 'Not' in 'Running' status"
+  KUBECTL_NS_OPERATOR get pod --field-selector status.phase!=Running | grep --invert-match Completed
+  if [ "$ROOK_OPERATOR_NAMESPACE" != "$ROOK_CLUSTER_NAMESPACE" ]; then
+    KUBECTL_NS_CLUSTER get pod --field-selector status.phase!=Running | grep --invert-match Completed
+  fi
+}
+
+function check_pg_are_active_clean() {
+  info_msg " checking placement group status"
+  pg_state=$(KUBECTL_NS_OPERATOR exec deploy/rook-ceph-operator -- ceph pg stat --conf="$CEPH_CONF_PATH")
+  pg_state_code=$(echo "${pg_state}" | awk '{print $4}')
+  if [[ "$pg_state_code" = *"active+clean;"* ]]; then
+    info_msg " $pg_state"
+  elif [[ "$pg_state_code" =~ down || "$pg_state_code" =~ incomplete || "$pg_state_code" =~ snaptrim_error ]]; then
+    error_msg " $pg_state"
+  else
+    warn_msg " $pg_state"
+  fi
+}
+
+function check_mgr_pods_status_and_count() {
+  info_msg " checking if at least one mgr pod is running"
+  mgr_pod_count=$(KUBECTL_NS_CLUSTER get pod -o=custom-columns=NAME:.metadata.name,STATUS:.status.phase | grep mgr | awk '{print $2}' | sort | uniq | wc -l)
+  if [ "$mgr_pod_count" -lt 1 ]; then
+    error_msg " At least one mgr pod should running"
+  fi
+  KUBECTL_NS_CLUSTER get pod -o=custom-columns=NAME:.metadata.name,STATUS:.status.phase,NODE:.spec.nodeName | grep mgr
 }
 
 ####################################################################################################
@@ -331,6 +428,9 @@ function run_main_command() {
   rook)
     rook_version "$@"
     ;;
+  health)
+    run_cluster_health "$@"
+    ;;
   # status)
   #   run_status_command "$@"
   #   ;;
@@ -344,6 +444,10 @@ function run_main_command() {
 : "${ROOK_CLUSTER_NAMESPACE:=rook-ceph}"
 : "${ROOK_OPERATOR_NAMESPACE:=$ROOK_CLUSTER_NAMESPACE}"
 : "${TOP_LEVEL_COMMAND:=kubectl}"
+: "${RESET:=\033[0m}"                           # For no color
+: "${ERROR_PREFIX:=\033[1;31mError:$RESET}"     # \033[1;31m for Red color
+: "${INFO_PREFIX:=\033[1;34mInfo:$RESET}"       # \033[1;34m for Blue color
+: "${WARNING_PREFIX:=\033[1;33mWarning:$RESET}" # \033[1;33m for Yellow color
 
 ####################################################################################################
 # MAIN: PARSE MAIN ARGS AND CALL MAIN COMMAND HANDLER

--- a/kubectl-rook-ceph.sh
+++ b/kubectl-rook-ceph.sh
@@ -165,7 +165,7 @@ function KUBECTL_NS_CLUSTER() {
 
 function run_ceph_command() {
   # do not call end_of_command_parsing here because all remaining input is passed directly to 'ceph'
-  KUBECTL_NS_OPERATOR exec deploy/rook-ceph-operator -- ceph "$@" --conf="$CEPH_CONF_PATH"
+  KUBECTL_NS_OPERATOR exec deploy/rook-ceph-operator -- ceph "$@" --connect-timeout=10 --conf="$CEPH_CONF_PATH"
 }
 
 ####################################################################################################

--- a/tests/github-action-helper.sh
+++ b/tests/github-action-helper.sh
@@ -32,6 +32,7 @@ deploy_rook() {
   kubectl create -f https://raw.githubusercontent.com/rook/rook/master/deploy/examples/operator.yaml
   curl https://raw.githubusercontent.com/rook/rook/master/deploy/examples/cluster-test.yaml -o cluster-test.yaml
   sed -i "s|#deviceFilter:|deviceFilter: $(lsblk | awk '/14G/ {print $1}' | head -1)|g" cluster-test.yaml
+  sed -i '0,/count: 1/ s/count: 1/count: 3/' cluster-test.yaml
   kubectl create -f cluster-test.yaml
   wait_for_pod_to_be_ready_state_default
   kubectl create -f https://raw.githubusercontent.com/rook/rook/master/deploy/examples/csi/rbd/storageclass-test.yaml
@@ -52,6 +53,7 @@ deploy_rook_in_custom_namespace() {
   deploy_with_custom_ns "$1" "$2" operator.yaml
   curl https://raw.githubusercontent.com/rook/rook/master/deploy/examples/cluster-test.yaml -o cluster-test.yaml
   sed -i "s|#deviceFilter:|deviceFilter: $(lsblk | awk '/14G/ {print $1}' | head -1)|g" cluster-test.yaml
+  sed -i '0,/count: 1/ s/count: 1/count: 3/' cluster-test.yaml
   deploy_with_custom_ns "$1" "$2" cluster-test.yaml
   wait_for_pod_to_be_ready_state_custom
   curl https://raw.githubusercontent.com/rook/rook/master/deploy/examples/csi/rbd/storageclass-test.yaml -o storageclass-test.yaml


### PR DESCRIPTION
This commit adds new command `kubectl rook-ceph health`,
which check cluster health, by looking at
1. minimum 3 mons on different nodes
2. minimum 3 osds on different nodes
3. all mons are in quorum
4. all pods state
5. pg active+clean
6. atleast one mgr pod running

Closes: #32 

Signed-off-by: subhamkrai <srai@redhat.com>