### PR TITLE
ci: added timeout instead of sleep commands

### DIFF
--- a/.github/workflows/ci-for-default-ns.yaml
+++ b/.github/workflows/ci-for-default-ns.yaml
@@ -75,15 +75,15 @@ jobs:
           # for testing start-debug and stop-debug deployment
           # mons
           kubectl rook_ceph debug start rook-ceph-mon-a
-          tkubectl-rook-ceph.sh wait_for_deployment_to_be_running rook-ceph-mon-a-debug rook-ceph
+          tests/github-action-helper.sh wait_for_deployment_to_be_running rook-ceph-mon-a-debug rook-ceph
           kubectl rook_ceph debug stop rook-ceph-mon-a
           # osd
           kubectl rook_ceph debug start rook-ceph-osd-0
-          kubectl-rook-ceph.sh wait_for_deployment_to_be_running rook-ceph-osd-0-debug rook-ceph
+          tests/github-action-helper.sh wait_for_deployment_to_be_running rook-ceph-osd-0-debug rook-ceph
           kubectl rook_ceph debug stop rook-ceph-osd-0
 
            # check if osd 0 is started
-          kubectl-rook-ceph.sh wait_for_deployment_to_be_running rook-ceph-osd-0 rook-ceph
+          tests/github-action-helper.sh wait_for_deployment_to_be_running rook-ceph-osd-0 rook-ceph
 
           # for testing osd purge scale the osd deplyment
           kubectl --namespace rook-ceph scale deploy/rook-ceph-osd-0 --replicas=0

--- a/.github/workflows/ci-for-default-ns.yaml
+++ b/.github/workflows/ci-for-default-ns.yaml
@@ -75,15 +75,15 @@ jobs:
           # for testing start-debug and stop-debug deployment
           # mons
           kubectl rook_ceph debug start rook-ceph-mon-a
-          sleep 5
+          tkubectl-rook-ceph.sh wait_for_deployment_to_be_running rook-ceph-mon-a-debug rook-ceph
           kubectl rook_ceph debug stop rook-ceph-mon-a
           # osd
           kubectl rook_ceph debug start rook-ceph-osd-0
-          sleep 5
+          kubectl-rook-ceph.sh wait_for_deployment_to_be_running rook-ceph-osd-0-debug rook-ceph
           kubectl rook_ceph debug stop rook-ceph-osd-0
 
-          # sleep again so OSD can start
-          sleep 5
+           # check if osd 0 is started
+          kubectl-rook-ceph.sh wait_for_deployment_to_be_running rook-ceph-osd-0 rook-ceph
 
           # for testing osd purge scale the osd deplyment
           kubectl --namespace rook-ceph scale deploy/rook-ceph-osd-0 --replicas=0

--- a/.github/workflows/ci-for-diff-ns.yaml
+++ b/.github/workflows/ci-for-diff-ns.yaml
@@ -57,6 +57,7 @@ jobs:
           tests/github-action-helper.sh wait_for_three_mons test-cluster
           kubectl -n test-cluster wait deployment rook-ceph-mon-d --for condition=Available=True --timeout=90s
           kubectl -n test-cluster wait deployment rook-ceph-mon-e --for condition=Available=True --timeout=90s
+<<<<<<< HEAD
 
           # for testing osd purge scale the osd deplyment
           kubectl --namespace test-cluster scale deploy/rook-ceph-osd-0 --replicas=0
@@ -64,18 +65,29 @@ jobs:
           sleep 5
           kubectl-rook_ceph -o test-operator -n test-cluster rook purge-osd 0 --force
           kubectl rook_ceph -o test-operator -n test-cluster health
+=======
+>>>>>>> 3007d8d (ci: added timeout instead of sleep commands)
 
           # for testing start-debug and stop-debug deployment
           # mon
           kubectl rook_ceph -o test-operator -n test-cluster debug start rook-ceph-mon-a
-          # sleep till the debug pod get running
-          sleep 5
+          kubectl-rook-ceph.sh wait_for_deployment_to_be_running rook-ceph-mon-a-debug test-cluster
           kubectl rook_ceph -o test-operator -n test-cluster debug stop rook-ceph-mon-a
           # osd
           kubectl rook_ceph -o test-operator -n test-cluster debug start rook-ceph-osd-0
-          # sleep till the debug pod get running
-          sleep 5
+          kubectl-rook-ceph.sh wait_for_deployment_to_be_running rook-ceph-osd-0-debug test-cluster
           kubectl rook_ceph -o test-operator -n test-cluster debug stop rook-ceph-osd-0
+
+           # check if osd 0 is started
+          kubectl-rook-ceph.sh wait_for_deployment_to_be_running rook-ceph-osd-0 test-cluster
+        
+          # for testing osd purge scale the osd deplyment
+          kubectl --namespace test-cluster scale deploy/rook-ceph-osd-0 --replicas=0
+          # we need to sleep so the osd will be marked down before purging the osd
+          sleep 5
+          kubectl-rook_ceph -o test-operator -n test-cluster rook purge-osd 0 --force
+          kubectl rook_ceph -o test-operator -n test-cluster health
+
 
       - name: setup tmate session for debugging when event is PR
         if: failure() && github.event_name == 'pull_request'

--- a/.github/workflows/ci-for-diff-ns.yaml
+++ b/.github/workflows/ci-for-diff-ns.yaml
@@ -57,29 +57,19 @@ jobs:
           tests/github-action-helper.sh wait_for_three_mons test-cluster
           kubectl -n test-cluster wait deployment rook-ceph-mon-d --for condition=Available=True --timeout=90s
           kubectl -n test-cluster wait deployment rook-ceph-mon-e --for condition=Available=True --timeout=90s
-<<<<<<< HEAD
-
-          # for testing osd purge scale the osd deplyment
-          kubectl --namespace test-cluster scale deploy/rook-ceph-osd-0 --replicas=0
-          # we need to sleep so the osd will be marked down before purging the osd
-          sleep 5
-          kubectl-rook_ceph -o test-operator -n test-cluster rook purge-osd 0 --force
-          kubectl rook_ceph -o test-operator -n test-cluster health
-=======
->>>>>>> 3007d8d (ci: added timeout instead of sleep commands)
 
           # for testing start-debug and stop-debug deployment
           # mon
           kubectl rook_ceph -o test-operator -n test-cluster debug start rook-ceph-mon-a
-          kubectl-rook-ceph.sh wait_for_deployment_to_be_running rook-ceph-mon-a-debug test-cluster
+          tests/github-action-helper.sh wait_for_deployment_to_be_running rook-ceph-mon-a-debug test-cluster
           kubectl rook_ceph -o test-operator -n test-cluster debug stop rook-ceph-mon-a
           # osd
           kubectl rook_ceph -o test-operator -n test-cluster debug start rook-ceph-osd-0
-          kubectl-rook-ceph.sh wait_for_deployment_to_be_running rook-ceph-osd-0-debug test-cluster
+          tests/github-action-helper.sh wait_for_deployment_to_be_running rook-ceph-osd-0-debug test-cluster
           kubectl rook_ceph -o test-operator -n test-cluster debug stop rook-ceph-osd-0
 
            # check if osd 0 is started
-          kubectl-rook-ceph.sh wait_for_deployment_to_be_running rook-ceph-osd-0 test-cluster
+          tests/github-action-helper.sh wait_for_deployment_to_be_running rook-ceph-osd-0 test-cluster
         
           # for testing osd purge scale the osd deplyment
           kubectl --namespace test-cluster scale deploy/rook-ceph-osd-0 --replicas=0

--- a/kubectl-rook-ceph.sh
+++ b/kubectl-rook-ceph.sh
@@ -244,7 +244,7 @@ function fetch_mon_endpoints() {
   KUBECTL_NS_CLUSTER get cm rook-ceph-mon-endpoints -o json | jq --monochrome-output '.data.data' | tr -d '"' | tr -d '=' | sed 's/[A-Za-z]*//g'
 }
 
-wait_for_deployment_to_be_running() {
+function wait_for_deployment_to_be_running() {
   deployment=$1
   info_msg "Waiting for the pod from deployment \"$deployment\" to be running"
   KUBECTL_NS_CLUSTER wait deployment $deployment --for condition=Available=True --timeout=90s

--- a/tests/github-action-helper.sh
+++ b/tests/github-action-helper.sh
@@ -118,6 +118,13 @@ wait_for_three_mons() {
 EOF
 }
 
+wait_for_deployment_to_be_running() {
+  deployment=$1
+  namespace=$2
+  echo "Waiting for the pod from deployment \"$deployment\" to be running"
+  kubectl -n "$namespace" wait deployment "$deployment" --for condition=Available=True --timeout=90s
+}
+
 ########
 # MAIN #
 ########


### PR DESCRIPTION
Instead of random sleep time, added timeout
so we will wait till the pods get started

Closes: https://github.com/rook/kubectl-rook-ceph/issues/42
Signed-off-by: parth-gr <paarora@redhat.com>