### PR TITLE
Remove redundant code

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ To install the plugin, run:
   - `stop  <deployment-name>` : Stop debugging a deployment
 
 - `dr` :
-  - `health [ceph status args]`: Print the cluster connection status of a peer cluster in a mirroring-enabled cluster. Ceph status args can be optionally passed, such as to change the log level: `--debug-ms 1`..
+  - `health [ceph status args]`: Print the `ceph status` of a peer cluster in a mirroring-enabled environment thereby validating connectivity between ceph clusters. Ceph status args can be optionally passed, such as to change the log level: `--debug-ms 1`.
 
 - `help` : Output help text
 

--- a/kubectl-rook-ceph.sh
+++ b/kubectl-rook-ceph.sh
@@ -51,7 +51,7 @@ function print_usage() {
            [--alternate-image <alternate-image>]    : Start debugging a deployment with an optional container image"
   echo "    stop <deployment-name>                  : Stop debugging a deployment"
   echo "  dr"
-  echo "    health [debug args]                     : Print the cluster connection status of a peer cluster in a mirroring-enabled cluster. Optional ceph args such as: '--debug-ms 1'."
+  echo "    health [debug args]                     : Print the ceph status of a peer cluster in a mirroring-enabled cluster. Optional ceph args such as: '--debug-ms 1'."
   echo ""
 }
 

--- a/kubectl-rook-ceph.sh
+++ b/kubectl-rook-ceph.sh
@@ -551,7 +551,7 @@ function run_dr_health() {
   PEER_KEY=$(KUBECTL_NS_CLUSTER get secret/"$SECRET_NAME" -o jsonpath='{.data.token}' | base64 --decode | base64 --decode | jq '.key' | sed -e 's/^.//' -e 's/.$//')
   # run ceph status command form one cluster to another
   echo
-  info_msg "running ceph status from other cluster details"
+  info_msg "running ceph status from peer cluster"
   run_ceph_command -s --mon-host "$MON_HOST" --id rbd-mirror-peer --key "$PEER_KEY" "$@"
   # run rbd pool mirror status
   info_msg "running mirroring daemon health"
@@ -634,16 +634,6 @@ function run_main_command() {
   esac
 }
 
-# Default values
-: "${ROOK_CLUSTER_NAMESPACE:=rook-ceph}"
-: "${ALTERNATE_IMAGE=}"
-: "${ROOK_OPERATOR_NAMESPACE:=$ROOK_CLUSTER_NAMESPACE}"
-: "${TOP_LEVEL_COMMAND:=kubectl}"
-: "${RESET:=\033[0m}"                           # For no color
-: "${ERROR_PREFIX:=\033[1;31mError:$RESET}"     # \033[1;31m for Red color
-: "${INFO_PREFIX:=\033[1;34mInfo:$RESET}"       # \033[1;34m for Blue color
-: "${WARNING_PREFIX:=\033[1;33mWarning:$RESET}" # \033[1;33m for Yellow color
-
 ####################################################################################################
 # MAIN: PARSE MAIN ARGS AND CALL MAIN COMMAND HANDLER
 ####################################################################################################
@@ -679,10 +669,12 @@ function parse_main_flag() {
 REMAINING_ARGS=()
 parse_flags 'parse_main_flag' "$@"
 
+# Note: don't move default values
 # Default values
 : "${ROOK_CLUSTER_NAMESPACE:=rook-ceph}"
 : "${ROOK_OPERATOR_NAMESPACE:=$ROOK_CLUSTER_NAMESPACE}"
 : "${TOP_LEVEL_COMMAND:=kubectl}"
+: "${ALTERNATE_IMAGE=}"
 : "${RESET:=\033[0m}"                           # For no color
 : "${ERROR_PREFIX:=\033[1;31mError:$RESET}"     # \033[1;31m for Red color
 : "${INFO_PREFIX:=\033[1;34mInfo:$RESET}"       # \033[1;34m for Blue color


### PR DESCRIPTION
core: move default values after the parsing flag
moving default flags after parsing flags and remove
redundant code.

Signed-off-by: subhamkrai <srai@redhat.com>