### PR TITLE
core: continue printing rbd pool status in failure

### DIFF
--- a/kubectl-rook-ceph.sh
+++ b/kubectl-rook-ceph.sh
@@ -554,6 +554,10 @@ function run_dr_health() {
   info_msg "running ceph status from peer cluster"
   set +e
   run_ceph_command -s --mon-host "$MON_HOST" --id rbd-mirror-peer --key "$PEER_KEY" "$@"
+  exitCode=$?
+  if [ $exitCode -ne 0 ]; then
+    error_msg "failed to get ceph status from peer cluster, please check for network issues between the clusters"
+  fi
   # run rbd pool mirror status
   info_msg "running mirroring daemon health"
   run_rbd_command -p "$blockpool_name" mirror pool status

--- a/kubectl-rook-ceph.sh
+++ b/kubectl-rook-ceph.sh
@@ -552,10 +552,12 @@ function run_dr_health() {
   # run ceph status command form one cluster to another
   echo
   info_msg "running ceph status from peer cluster"
+  set +e
   run_ceph_command -s --mon-host "$MON_HOST" --id rbd-mirror-peer --key "$PEER_KEY" "$@"
   # run rbd pool mirror status
   info_msg "running mirroring daemon health"
   run_rbd_command -p "$blockpool_name" mirror pool status
+  set -e
 }
 
 ####################################################################################################


### PR DESCRIPTION
In dr, if ceph status command fails for peer cluster we should continue to print rbd pool stat of local cluster. So, setting `set +e` will do the trick here.

Signed-off-by: subhamkrai <srai@redhat.com>