### PR TITLE
ci: move commands in specific section

### DIFF
--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -32,13 +32,19 @@ jobs:
           sudo cp bin/kubectl-rook-ceph /usr/local/bin/kubectl-rook_ceph
           make test
 
-      - name: Test plugin with ceph commands
+      - name: Cluster Health
         run: |
           set -e
           kubectl rook-ceph health
 
+      - name: Ceph status
+        run: |
+          set -ex
           kubectl rook-ceph ceph status
 
+      - name: Mon restore
+        run: |
+          set -ex
           # test the mon restore to restore to mon a, delete mons b and c, then add d and e
           export ROOK_PLUGIN_SKIP_PROMPTS=true
           kubectl rook-ceph  mons restore-quorum a
@@ -48,25 +54,50 @@ jobs:
           kubectl -n rook-ceph wait deployment rook-ceph-mon-d --for condition=Available=True --timeout=90s
           kubectl -n rook-ceph wait deployment rook-ceph-mon-e --for condition=Available=True --timeout=90s
 
-
-          kubectl rook-ceph mons
+      - name: Rbd command
+        run: |
+          set -ex
           kubectl rook-ceph rbd ls replicapool
 
-          POD=$(kubectl -n rook-ceph get pod -l app=rook-ceph-operator -o jsonpath="{.items[0].metadata.name}")
+      - name: Get mon endpoints
+        run: |
+          set -ex
+          kubectl rook-ceph mons
+
+      - name: Update operator configmap
+        run: |
+          set -ex
+          kubectl rook-ceph operator set ROOK_LOG_LEVEL DEBUG
+
+      - name: Print cr status
+        run: |
+          set -ex
+          kubectl rook-ceph rook version
+          kubectl rook-ceph rook status
+          kubectl rook-ceph rook status all
+          kubectl rook-ceph rook status cephobjectstores
+
+      - name: Restart operator pod
+        run: |
+          set -ex
           kubectl rook-ceph operator restart
           # let's wait for operator pod to be restart
+          POD=$(kubectl -n rook-ceph get pod -l app=rook-ceph-operator -o jsonpath="{.items[0].metadata.name}")
           kubectl -n rook-ceph wait --for=delete pod/$POD --timeout=100s
           tests/github-action-helper.sh wait_for_operator_pod_to_be_ready_state_default
+
+      - name: Debug Mode
+        run: |
+          set -ex
           kubectl rook_ceph debug start rook-ceph-osd-0
           tests/github-action-helper.sh wait_for_deployment_to_be_running rook-ceph-osd-0-debug rook-ceph
 
           kubectl rook_ceph debug stop rook-ceph-osd-0
           tests/github-action-helper.sh wait_for_deployment_to_be_running rook-ceph-osd-0 rook-ceph
-          kubectl rook-ceph operator set ROOK_LOG_LEVEL DEBUG
-          kubectl rook-ceph rook version
-          kubectl rook-ceph rook status
-          kubectl rook-ceph rook status all
-          kubectl rook-ceph rook status cephobjectstores
+
+      - name: Purge Osd
+        run: |
+          set -ex
           kubectl rook-ceph rook purge-osd 0 --force
 
       - name: collect common logs


### PR DESCRIPTION
ci: move commands in a specific section

currently, all the commands are in the same
test name, it's better to split the commands
in the individual section.

Signed-off-by: subhamkrai <srai@redhat.com>
