### PR TITLE
core: don't use context.ToDo everywhere

### DIFF
--- a/cmd/commands/root.go
+++ b/cmd/commands/root.go
@@ -84,5 +84,7 @@ func GetContext() *k8sutil.Context {
 		logging.Fatal(err)
 	}
 
+	context.Context = RootCmd.Context()
+
 	return context
 }

--- a/pkg/debug/start_debug.go
+++ b/pkg/debug/start_debug.go
@@ -17,7 +17,6 @@ limitations under the License.
 package debug
 
 import (
-	ctx "context"
 	"fmt"
 	"time"
 
@@ -88,7 +87,7 @@ func startDebug(context *k8sutil.Context, clusterNamespace, deploymentName, alte
 		Spec: deployment.Spec,
 	}
 
-	debugDeployment, err := context.Clientset.AppsV1().Deployments(clusterNamespace).Create(ctx.TODO(), debugDeploymentSpec, v1.CreateOptions{})
+	debugDeployment, err := context.Clientset.AppsV1().Deployments(clusterNamespace).Create(context.Context, debugDeploymentSpec, v1.CreateOptions{})
 	if err != nil {
 		return fmt.Errorf("Error creating deployment %s. %v\n", debugDeploymentSpec, err)
 	}
@@ -111,7 +110,7 @@ func SetDeploymentScale(context *k8sutil.Context, clusterNamespace, deploymentNa
 			Replicas: int32(scaleCount),
 		},
 	}
-	_, err := context.Clientset.AppsV1().Deployments(clusterNamespace).UpdateScale(ctx.TODO(), deploymentName, scale, v1.UpdateOptions{})
+	_, err := context.Clientset.AppsV1().Deployments(clusterNamespace).UpdateScale(context.Context, deploymentName, scale, v1.UpdateOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to update scale of deployment %s. %v\n", deploymentName, err)
 	}
@@ -120,7 +119,7 @@ func SetDeploymentScale(context *k8sutil.Context, clusterNamespace, deploymentNa
 
 func GetDeployment(context *k8sutil.Context, clusterNamespace, deploymentName string) (*appsv1.Deployment, error) {
 	logging.Info("fetching the deployment %s to be running\n", deploymentName)
-	deployment, err := context.Clientset.AppsV1().Deployments(clusterNamespace).Get(ctx.TODO(), deploymentName, v1.GetOptions{})
+	deployment, err := context.Clientset.AppsV1().Deployments(clusterNamespace).Get(context.Context, deploymentName, v1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -131,7 +130,7 @@ func GetDeployment(context *k8sutil.Context, clusterNamespace, deploymentName st
 
 func waitForPodDeletion(context *k8sutil.Context, clusterNamespace, podName string) error {
 	for i := 0; i < 60; i++ {
-		_, err := context.Clientset.CoreV1().Pods(clusterNamespace).Get(ctx.TODO(), podName, v1.GetOptions{})
+		_, err := context.Clientset.CoreV1().Pods(clusterNamespace).Get(context.Context, podName, v1.GetOptions{})
 		if kerrors.IsNotFound(err) {
 			return nil
 		}

--- a/pkg/debug/stop_debug.go
+++ b/pkg/debug/stop_debug.go
@@ -17,7 +17,6 @@ limitations under the License.
 package debug
 
 import (
-	ctx "context"
 	"fmt"
 	"strings"
 
@@ -47,7 +46,7 @@ func stopDebug(context *k8sutil.Context, clusterNamespace, deploymentName string
 	}
 
 	logging.Info("removing debug mode from deployment %s\n", debugDeployment.Name)
-	err = context.Clientset.AppsV1().Deployments(clusterNamespace).Delete(ctx.TODO(), debugDeployment.Name, v1.DeleteOptions{})
+	err = context.Clientset.AppsV1().Deployments(clusterNamespace).Delete(context.Context, debugDeployment.Name, v1.DeleteOptions{})
 	if err != nil && !kerrors.IsNotFound(err) {
 		return fmt.Errorf("Error deleting deployment %s: %v", debugDeployment.Name, err)
 	}

--- a/pkg/dr/health.go
+++ b/pkg/dr/health.go
@@ -1,7 +1,6 @@
 package dr
 
 import (
-	ctx "context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -22,7 +21,7 @@ type secretData struct {
 
 func Health(context *k8sutil.Context, operatorNamespace, cephClusterNamespace string, args []string) {
 	fmt.Println("INFO: fetching the cephblockpools with mirroring enabled")
-	blockPoolList, err := context.RookClientset.CephV1().CephBlockPools(cephClusterNamespace).List(ctx.TODO(), v1.ListOptions{})
+	blockPoolList, err := context.RookClientset.CephV1().CephBlockPools(cephClusterNamespace).List(context.Context, v1.ListOptions{})
 	if err != nil {
 		log.Error(err)
 	}
@@ -76,7 +75,7 @@ func Health(context *k8sutil.Context, operatorNamespace, cephClusterNamespace st
 }
 
 func extractSecretData(context *k8sutil.Context, operatorNamespace, cephClusterNamespace, secretName string) (*secretData, error) {
-	secret, err := context.Clientset.CoreV1().Secrets(cephClusterNamespace).Get(ctx.TODO(), secretName, v1.GetOptions{})
+	secret, err := context.Clientset.CoreV1().Secrets(cephClusterNamespace).Get(context.Context, secretName, v1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -18,7 +18,6 @@ package exec
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"io"
 	"os"
@@ -78,7 +77,7 @@ func RunCommandInToolboxPod(ctx *k8sutil.Context, cmd string, args []string, clu
 
 func RunCommandInLabeledPod(ctx *k8sutil.Context, label, container, cmd string, args []string, clusterNamespace string, exitOnError bool) string {
 	opts := metav1.ListOptions{LabelSelector: label}
-	list, err := ctx.Clientset.CoreV1().Pods(clusterNamespace).List(context.TODO(), opts)
+	list, err := ctx.Clientset.CoreV1().Pods(clusterNamespace).List(ctx.Context, opts)
 	if err != nil || len(list.Items) == 0 {
 		logging.Fatal(fmt.Errorf("failed to get rook mon pod where the command could be executed. %v", err))
 	}
@@ -133,7 +132,7 @@ func execCmdInPod(ctx *k8sutil.Context, command, podName, containerName, podName
 	}
 
 	// Connect this process' std{in,out,err} to the remote shell process.
-	return exec.StreamWithContext(context.TODO(), remotecommand.StreamOptions{
+	return exec.StreamWithContext(ctx.Context, remotecommand.StreamOptions{
 		Stdin:  os.Stdin,
 		Stdout: stdout,
 		Stderr: stderr,

--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -17,7 +17,6 @@ limitations under the License.
 package health
 
 import (
-	ctx "context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -82,7 +81,7 @@ func checkPodsOnNodes(context *k8sutil.Context, clusterNamespace, label string) 
 	}
 
 	opts := metav1.ListOptions{LabelSelector: label}
-	podList, err := context.Clientset.CoreV1().Pods(clusterNamespace).List(ctx.TODO(), opts)
+	podList, err := context.Clientset.CoreV1().Pods(clusterNamespace).List(context.Context, opts)
 	if err != nil {
 		logging.Error(fmt.Errorf("failed to list %s pods with label %s: %v", daemonType, opts.LabelSelector, err))
 	}
@@ -138,7 +137,7 @@ func CheckAllPodsStatus(context *k8sutil.Context, operatorNamespace, clusterName
 
 func getPodRunningStatus(context *k8sutil.Context, namespace string) ([]v1.Pod, []v1.Pod) {
 	var podNotRunning, podRunning []v1.Pod
-	podList, err := context.Clientset.CoreV1().Pods(namespace).List(ctx.TODO(), metav1.ListOptions{})
+	podList, err := context.Clientset.CoreV1().Pods(namespace).List(context.Context, metav1.ListOptions{})
 	if err != nil {
 		logging.Error(fmt.Errorf("\nfailed to list pods in namespace %s: %v\n", namespace, err))
 	}
@@ -168,7 +167,7 @@ func checkPgStatus(context *k8sutil.Context, operatorNamespace, clusterNamespace
 
 func checkMgrPodsStatusAndCounts(context *k8sutil.Context, clusterNamespace string) {
 	opts := metav1.ListOptions{LabelSelector: "app=rook-ceph-mgr"}
-	podList, err := context.Clientset.CoreV1().Pods(clusterNamespace).List(ctx.TODO(), opts)
+	podList, err := context.Clientset.CoreV1().Pods(clusterNamespace).List(context.Context, opts)
 	if err != nil {
 		logging.Error(fmt.Errorf("\nfailed to list mgr pods with label %s: %v\n", opts.LabelSelector, err))
 		return

--- a/pkg/k8sutil/context.go
+++ b/pkg/k8sutil/context.go
@@ -17,6 +17,8 @@ limitations under the License.
 package k8sutil
 
 import (
+	"context"
+
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -36,4 +38,6 @@ type Context struct {
 
 	// RookClientset is a typed connection to the rook API
 	RookClientset rookclient.Interface
+
+	Context context.Context
 }

--- a/pkg/k8sutil/operator.go
+++ b/pkg/k8sutil/operator.go
@@ -17,7 +17,6 @@ limitations under the License.
 package k8sutil
 
 import (
-	"context"
 	"fmt"
 	"time"
 
@@ -31,7 +30,7 @@ import (
 func RestartDeployment(ctx *Context, namespace, deploymentName string) {
 	deploymentsClient := ctx.Clientset.AppsV1().Deployments(namespace)
 	data := fmt.Sprintf(`{"spec": {"template": {"metadata": {"annotations": {"kubectl.kubernetes.io/restartedAt": "%s"}}}}}`, time.Now().String())
-	_, err := deploymentsClient.Patch(context.TODO(), deploymentName, types.StrategicMergePatchType, []byte(data), v1.PatchOptions{})
+	_, err := deploymentsClient.Patch(ctx.Context, deploymentName, types.StrategicMergePatchType, []byte(data), v1.PatchOptions{})
 	if err != nil {
 		logging.Error(fmt.Errorf("Failed to delete deployment %s: %v", deploymentName, err))
 	}
@@ -42,7 +41,7 @@ func RestartDeployment(ctx *Context, namespace, deploymentName string) {
 func WaitForPodToRun(ctx *Context, operatorNamespace, labelSelector string) (corev1.Pod, error) {
 	opts := v1.ListOptions{LabelSelector: labelSelector}
 	for i := 0; i < 60; i++ {
-		pod, err := ctx.Clientset.CoreV1().Pods(operatorNamespace).List(context.TODO(), opts)
+		pod, err := ctx.Clientset.CoreV1().Pods(operatorNamespace).List(ctx.Context, opts)
 		if err != nil {
 			return corev1.Pod{}, fmt.Errorf("failed to list pods with labels matching %s", labelSelector)
 		}
@@ -58,13 +57,13 @@ func WaitForPodToRun(ctx *Context, operatorNamespace, labelSelector string) (cor
 }
 
 func UpdateConfigMap(ctx *Context, namespace, configMapName, key, value string) {
-	cm, err := ctx.Clientset.CoreV1().ConfigMaps(namespace).Get(context.TODO(), configMapName, v1.GetOptions{})
+	cm, err := ctx.Clientset.CoreV1().ConfigMaps(namespace).Get(ctx.Context, configMapName, v1.GetOptions{})
 	if err != nil {
 		logging.Fatal(err)
 	}
 
 	cm.Data[key] = value
-	_, err = ctx.Clientset.CoreV1().ConfigMaps(namespace).Update(context.TODO(), cm, v1.UpdateOptions{})
+	_, err = ctx.Clientset.CoreV1().ConfigMaps(namespace).Update(ctx.Context, cm, v1.UpdateOptions{})
 	if err != nil {
 		logging.Fatal(err)
 	}

--- a/pkg/mons/mon_endpoints.go
+++ b/pkg/mons/mon_endpoints.go
@@ -16,7 +16,6 @@ limitations under the License.
 package mons
 
 import (
-	ctx "context"
 	"fmt"
 	"regexp"
 
@@ -28,7 +27,7 @@ import (
 const MonConfigMap = "rook-ceph-mon-endpoints"
 
 func GetMonEndpoint(context *k8sutil.Context, clusterNamespace string) string {
-	monCm, err := context.Clientset.CoreV1().ConfigMaps(clusterNamespace).Get(ctx.TODO(), MonConfigMap, v1.GetOptions{})
+	monCm, err := context.Clientset.CoreV1().ConfigMaps(clusterNamespace).Get(context.Context, MonConfigMap, v1.GetOptions{})
 	if err != nil {
 		logging.Error(fmt.Errorf("failed to get mon configmap %s %v", MonConfigMap, err))
 	}

--- a/pkg/rook/purge_osd.go
+++ b/pkg/rook/purge_osd.go
@@ -17,7 +17,6 @@ limitations under the License.
 package rook
 
 import (
-	ctx "context"
 	"fmt"
 
 	"github.com/rook/kubectl-rook-ceph/pkg/exec"
@@ -28,7 +27,7 @@ import (
 )
 
 func PurgeOsd(context *k8sutil.Context, operatorNamespace, clusterNamespace, osdId, flag string) string {
-	monCm, err := context.Clientset.CoreV1().ConfigMaps(clusterNamespace).Get(ctx.TODO(), mons.MonConfigMap, v1.GetOptions{})
+	monCm, err := context.Clientset.CoreV1().ConfigMaps(clusterNamespace).Get(context.Context, mons.MonConfigMap, v1.GetOptions{})
 	if err != nil {
 		logging.Fatal(fmt.Errorf("failed to get mon configmap %s %v", mons.MonConfigMap, err))
 	}


### PR DESCRIPTION
core: don't use context.ToDo everywhere

using context.ToDo always is not a good practice.
So, now having a central place of context which
all methods will use.

Signed-off-by: subhamkrai <srai@redhat.com>