### PR TITLE
status: remove extra empty line logging

### DIFF
--- a/pkg/logging/log.go
+++ b/pkg/logging/log.go
@@ -24,8 +24,11 @@ import (
 
 func Info(output string, args ...interface{}) {
 	blue := color.New(color.FgBlue).SprintFunc()
-	fmt.Print(blue("Info: "))
-	fmt.Printf(output, args...)
+	if output != "" {
+		fmt.Print(blue("Info: "))
+		fmt.Printf(output, args...)
+	}
+
 	fmt.Println()
 }
 

--- a/pkg/rook/status.go
+++ b/pkg/rook/status.go
@@ -36,11 +36,11 @@ func PrintCustomResourceStatus(clusterNamespace string, arg []string) {
 	if len(arg) == 1 && arg[0] == "all" {
 		command := fmt.Sprintf(getCrdList, clusterNamespace)
 		allCRs := strings.Split(exec.ExecuteBashCommand(command), "\n")
-		logging.Info(allCRs[0])
+		allCRs = allCRs[:len(allCRs)-1] // remove last empty line which is not a CR
 		for _, cr := range allCRs {
 			logging.Info(cr)
 			command := fmt.Sprintf(scriptPrintSpecificCRStatus, clusterNamespace, cr)
-			logging.Info(exec.ExecuteBashCommand(command))
+			fmt.Println(exec.ExecuteBashCommand(command))
 		}
 
 	} else if len(arg) == 1 {


### PR DESCRIPTION
status: remove extra empty line logging

changing Info() method to print `Info` and
logs with new line only when output is not empty
otherwise it will print `Info:` with empty line.


fixes: #102 