### PR TITLE
Use recommended context.Context passing

### DIFF
--- a/cmd/commands/ceph.go
+++ b/cmd/commands/ceph.go
@@ -31,7 +31,7 @@ var CephCmd = &cobra.Command{
 	DisableFlagParsing: true,
 	Args:               cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		context := GetContext()
-		fmt.Println(exec.RunCommandInOperatorPod(context, cmd.Use, args, OperatorNamespace, CephClusterNamespace, true))
+		clientsets := GetClientsets()
+		fmt.Println(exec.RunCommandInOperatorPod(cmd.Context(), clientsets, cmd.Use, args, OperatorNamespace, CephClusterNamespace, true))
 	},
 }

--- a/cmd/commands/debug.go
+++ b/cmd/commands/debug.go
@@ -34,9 +34,9 @@ var startDebugCmd = &cobra.Command{
 	Short: "Start debugging a deployment with an optional alternative ceph container image",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		context := GetContext()
+		clientsets := GetClientsets()
 		alternateImage := cmd.Flag("alternate-image").Value.String()
-		debug.StartDebug(context, CephClusterNamespace, args[0], alternateImage)
+		debug.StartDebug(cmd.Context(), clientsets.Kube, CephClusterNamespace, args[0], alternateImage)
 	},
 }
 
@@ -44,9 +44,9 @@ var stopDebugCmd = &cobra.Command{
 	Use:   "stop",
 	Short: "Stop debugging a deployment",
 	Args:  cobra.ExactArgs(1),
-	Run: func(_ *cobra.Command, args []string) {
-		context := GetContext()
-		debug.StopDebug(context, CephClusterNamespace, args[0])
+	Run: func(cmd *cobra.Command, args []string) {
+		clientsets := GetClientsets()
+		debug.StopDebug(cmd.Context(), clientsets.Kube, CephClusterNamespace, args[0])
 	},
 }
 

--- a/cmd/commands/dr_health.go
+++ b/cmd/commands/dr_health.go
@@ -17,9 +17,9 @@ var healthCmd = &cobra.Command{
 	Short:              "Print the ceph status of a peer cluster in a mirroring-enabled cluster.",
 	DisableFlagParsing: true,
 	Args:               cobra.MaximumNArgs(2),
-	Run: func(_ *cobra.Command, args []string) {
-		context := GetContext()
-		dr.Health(context, OperatorNamespace, CephClusterNamespace, args)
+	Run: func(cmd *cobra.Command, args []string) {
+		clientsets := GetClientsets()
+		dr.Health(cmd.Context(), clientsets, OperatorNamespace, CephClusterNamespace, args)
 	},
 }
 

--- a/cmd/commands/health.go
+++ b/cmd/commands/health.go
@@ -26,8 +26,8 @@ var Health = &cobra.Command{
 	Short:              "check health of the cluster and common configuration issues",
 	DisableFlagParsing: true,
 	Args:               cobra.NoArgs,
-	Run: func(_ *cobra.Command, _ []string) {
-		context := GetContext()
-		health.Health(context, OperatorNamespace, CephClusterNamespace)
+	Run: func(cmd *cobra.Command, _ []string) {
+		clientsets := GetClientsets()
+		health.Health(cmd.Context(), clientsets, OperatorNamespace, CephClusterNamespace)
 	},
 }

--- a/cmd/commands/mons.go
+++ b/cmd/commands/mons.go
@@ -30,10 +30,10 @@ var MonCmd = &cobra.Command{
 	Short:              "Output mon endpoints",
 	DisableFlagParsing: true,
 	Args:               cobra.MaximumNArgs(1),
-	Run: func(_ *cobra.Command, args []string) {
+	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
-			context := GetContext()
-			fmt.Println(mons.GetMonEndpoint(context, CephClusterNamespace))
+			clientsets := GetClientsets()
+			fmt.Println(mons.GetMonEndpoint(cmd.Context(), clientsets.Kube, CephClusterNamespace))
 		}
 	},
 }
@@ -44,9 +44,9 @@ var RestoreQuorum = &cobra.Command{
 	Short:              "When quorum is lost, restore quorum to the remaining healthy mon",
 	DisableFlagParsing: true,
 	Args:               cobra.ExactArgs(1),
-	Run: func(_ *cobra.Command, args []string) {
-		context := GetContext()
-		mons.RestoreQuorum(context, OperatorNamespace, CephClusterNamespace, args[0])
+	Run: func(cmd *cobra.Command, args []string) {
+		clientsets := GetClientsets()
+		mons.RestoreQuorum(cmd.Context(), clientsets, OperatorNamespace, CephClusterNamespace, args[0])
 	},
 }
 

--- a/cmd/commands/operator.go
+++ b/cmd/commands/operator.go
@@ -34,9 +34,9 @@ var restartCmd = &cobra.Command{
 	Use:   "restart",
 	Short: "Restart rook-ceph-operator pod",
 	Args:  cobra.NoArgs,
-	Run: func(_ *cobra.Command, _ []string) {
-		context := GetContext()
-		k8sutil.RestartDeployment(context, OperatorNamespace, "rook-ceph-operator")
+	Run: func(cmd *cobra.Command, args []string) {
+		clientsets := GetClientsets()
+		k8sutil.RestartDeployment(cmd.Context(), clientsets.Kube, OperatorNamespace, "rook-ceph-operator")
 	},
 }
 
@@ -44,9 +44,9 @@ var setCmd = &cobra.Command{
 	Use:   "set",
 	Short: "Set the property in the rook-ceph-operator-config configmap.",
 	Args:  cobra.ExactArgs(2),
-	Run: func(_ *cobra.Command, args []string) {
-		context := GetContext()
-		k8sutil.UpdateConfigMap(context, OperatorNamespace, "rook-ceph-operator-config", args[0], args[1])
+	Run: func(cmd *cobra.Command, args []string) {
+		clientsets := GetClientsets()
+		k8sutil.UpdateConfigMap(cmd.Context(), clientsets.Kube, OperatorNamespace, "rook-ceph-operator-config", args[0], args[1])
 	},
 }
 

--- a/cmd/commands/rbd.go
+++ b/cmd/commands/rbd.go
@@ -31,7 +31,7 @@ var RbdCmd = &cobra.Command{
 	DisableFlagParsing: true,
 	Args:               cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		context := GetContext()
-		fmt.Println(exec.RunCommandInOperatorPod(context, cmd.Use, args, OperatorNamespace, CephClusterNamespace, true))
+		clientsets := GetClientsets()
+		fmt.Println(exec.RunCommandInOperatorPod(cmd.Context(), clientsets, cmd.Use, args, OperatorNamespace, CephClusterNamespace, true))
 	},
 }

--- a/cmd/commands/rook.go
+++ b/cmd/commands/rook.go
@@ -36,8 +36,8 @@ var versionCmd = &cobra.Command{
 	Short: "Prints rook version",
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, _ []string) {
-		context := GetContext()
-		fmt.Println(exec.RunCommandInOperatorPod(context, "rook", []string{cmd.Use}, OperatorNamespace, CephClusterNamespace, true))
+		clientsets := GetClientsets()
+		fmt.Println(exec.RunCommandInOperatorPod(cmd.Context(), clientsets, "rook", []string{cmd.Use}, OperatorNamespace, CephClusterNamespace, true))
 	},
 }
 
@@ -46,10 +46,10 @@ var purgeCmd = &cobra.Command{
 	Short: "Permanently remove an OSD from the cluster. Multiple OSDs can be removed with a comma-separated list of IDs.",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		context := GetContext()
+		clientsets := GetClientsets()
 		forceflagValue := cmd.Flag("force").Value.String()
 		osdID := args[0]
-		rook.PurgeOsd(context, OperatorNamespace, CephClusterNamespace, osdID, forceflagValue)
+		rook.PurgeOsd(cmd.Context(), clientsets, OperatorNamespace, CephClusterNamespace, osdID, forceflagValue)
 	},
 }
 

--- a/cmd/commands/root.go
+++ b/cmd/commands/root.go
@@ -53,10 +53,10 @@ func init() {
 	RootCmd.PersistentFlags().StringVar(&CephClusterNamespace, "namespace", "rook-ceph", "Kubernetes namespace where ceph cluster is created")
 }
 
-func GetContext() *k8sutil.Context {
+func GetClientsets() *k8sutil.Clientsets {
 	var err error
 
-	context := &k8sutil.Context{}
+	clientsets := &k8sutil.Clientsets{}
 
 	// 1. Create Kubernetes Client
 	kubeconfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
@@ -64,27 +64,20 @@ func GetContext() *k8sutil.Context {
 		&clientcmd.ConfigOverrides{},
 	)
 
-	context.KubeConfig, err = kubeconfig.ClientConfig()
+	clientsets.KubeConfig, err = kubeconfig.ClientConfig()
 	if err != nil {
 		logging.Fatal(err)
 	}
 
-	context.RookClientset, err = rookclient.NewForConfig(context.KubeConfig)
+	clientsets.Rook, err = rookclient.NewForConfig(clientsets.KubeConfig)
 	if err != nil {
 		logging.Fatal(err)
 	}
 
-	context.RookClientset, err = rookclient.NewForConfig(context.KubeConfig)
+	clientsets.Kube, err = k8s.NewForConfig(clientsets.KubeConfig)
 	if err != nil {
 		logging.Fatal(err)
 	}
 
-	context.Clientset, err = k8s.NewForConfig(context.KubeConfig)
-	if err != nil {
-		logging.Fatal(err)
-	}
-
-	context.Context = RootCmd.Context()
-
-	return context
+	return clientsets
 }

--- a/pkg/k8sutil/context.go
+++ b/pkg/k8sutil/context.go
@@ -17,27 +17,19 @@ limitations under the License.
 package k8sutil
 
 import (
-	"context"
-
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	rookclient "github.com/rook/rook/pkg/client/clientset/versioned"
 )
 
-type Context struct {
-	// The kubernetes config used for this context
+type Clientsets struct {
+	// The Kubernetes config used for these client sets
 	KubeConfig *rest.Config
 
-	// Clientset is a connection to the core kubernetes API
-	Clientset kubernetes.Interface
+	// Kube is a connection to the core Kubernetes API
+	Kube kubernetes.Interface
 
-	// Represents the Client provided by the controller-runtime package to interact with Kubernetes objects
-	Client client.Client
-
-	// RookClientset is a typed connection to the rook API
-	RookClientset rookclient.Interface
-
-	Context context.Context
+	// Rook is a typed connection to the rook API
+	Rook rookclient.Interface
 }

--- a/pkg/mons/mon_endpoints.go
+++ b/pkg/mons/mon_endpoints.go
@@ -16,18 +16,19 @@ limitations under the License.
 package mons
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 
-	"github.com/rook/kubectl-rook-ceph/pkg/k8sutil"
 	"github.com/rook/kubectl-rook-ceph/pkg/logging"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 )
 
 const MonConfigMap = "rook-ceph-mon-endpoints"
 
-func GetMonEndpoint(context *k8sutil.Context, clusterNamespace string) string {
-	monCm, err := context.Clientset.CoreV1().ConfigMaps(clusterNamespace).Get(context.Context, MonConfigMap, v1.GetOptions{})
+func GetMonEndpoint(ctx context.Context, k8sclientset kubernetes.Interface, clusterNamespace string) string {
+	monCm, err := k8sclientset.CoreV1().ConfigMaps(clusterNamespace).Get(ctx, MonConfigMap, v1.GetOptions{})
 	if err != nil {
 		logging.Error(fmt.Errorf("failed to get mon configmap %s %v", MonConfigMap, err))
 	}

--- a/pkg/mons/mon_endpoints_test.go
+++ b/pkg/mons/mon_endpoints_test.go
@@ -31,8 +31,8 @@ func TestParseMonEndpoint(t *testing.T) {
 
 	newClient := fake.NewSimpleClientset
 	k8s := newClient()
-	context := k8sutil.Context{
-		Clientset: k8s,
+	clientsets := k8sutil.Clientsets{
+		Kube: k8s,
 	}
 	ns := "rook-ceph"
 
@@ -45,10 +45,10 @@ func TestParseMonEndpoint(t *testing.T) {
 			"data": "10.96.52.53:6789",
 		},
 	}
-	_, err := context.Clientset.CoreV1().ConfigMaps(ns).Create(ctx, cm, metav1.CreateOptions{})
+	_, err := clientsets.Kube.CoreV1().ConfigMaps(ns).Create(ctx, cm, metav1.CreateOptions{})
 	assert.NoError(t, err)
 
-	monData := GetMonEndpoint(&context, ns)
+	monData := GetMonEndpoint(context.TODO(), clientsets.Kube, ns)
 	assert.Equal(t, "10.96.52.53:6789", monData)
 	assert.NotEqual(t, "10.96.52.54:6789", monData)
 

--- a/pkg/rook/purge_osd.go
+++ b/pkg/rook/purge_osd.go
@@ -17,6 +17,7 @@ limitations under the License.
 package rook
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/rook/kubectl-rook-ceph/pkg/exec"
@@ -26,8 +27,8 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func PurgeOsd(context *k8sutil.Context, operatorNamespace, clusterNamespace, osdId, flag string) string {
-	monCm, err := context.Clientset.CoreV1().ConfigMaps(clusterNamespace).Get(context.Context, mons.MonConfigMap, v1.GetOptions{})
+func PurgeOsd(ctx context.Context, clientsets *k8sutil.Clientsets, operatorNamespace, clusterNamespace, osdId, flag string) string {
+	monCm, err := clientsets.Kube.CoreV1().ConfigMaps(clusterNamespace).Get(ctx, mons.MonConfigMap, v1.GetOptions{})
 	if err != nil {
 		logging.Fatal(fmt.Errorf("failed to get mon configmap %s %v", mons.MonConfigMap, err))
 	}
@@ -36,7 +37,7 @@ func PurgeOsd(context *k8sutil.Context, operatorNamespace, clusterNamespace, osd
 	cephArgs := []string{
 		"auth", "print-key", "client.admin",
 	}
-	adminKey := exec.RunCommandInOperatorPod(context, "ceph", cephArgs, operatorNamespace, clusterNamespace, true)
+	adminKey := exec.RunCommandInOperatorPod(ctx, clientsets, "ceph", cephArgs, operatorNamespace, clusterNamespace, true)
 
 	cmd := "/bin/sh"
 	args := []string{
@@ -45,5 +46,5 @@ func PurgeOsd(context *k8sutil.Context, operatorNamespace, clusterNamespace, osd
 	}
 
 	logging.Info("Running purge osd command")
-	return exec.RunCommandInOperatorPod(context, cmd, args, operatorNamespace, clusterNamespace, true)
+	return exec.RunCommandInOperatorPod(ctx, clientsets, cmd, args, operatorNamespace, clusterNamespace, true)
 }


### PR DESCRIPTION
Documentation in context.Context states never to embed a context.Context in a struct. It should always be passed to functions and methods, ideally as the first parameter. Kubernetes' Go API follows this syntax, and since it is much easier to fix the issue in kubectl-rook-ceph compared to in rook/rook, we should do so.

The old k8sutil.Context has been renamed to k8sutil.Clientsets to reflect its new purpose.