### PR TITLE
Fix parsing for namespace flags

### DIFF
--- a/cmd/commands/ceph.go
+++ b/cmd/commands/ceph.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 
 	"github.com/rook/kubectl-rook-ceph/pkg/exec"
-
+	"github.com/rook/kubectl-rook-ceph/pkg/logging"
 	"github.com/spf13/cobra"
 )
 
@@ -32,6 +32,7 @@ var CephCmd = &cobra.Command{
 	Args:               cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		clientsets := GetClientsets()
+		logging.Info("running 'ceph' command with args: %v", args)
 		fmt.Println(exec.RunCommandInOperatorPod(cmd.Context(), clientsets, cmd.Use, args, OperatorNamespace, CephClusterNamespace, true))
 	},
 }

--- a/cmd/commands/root.go
+++ b/cmd/commands/root.go
@@ -33,9 +33,14 @@ var (
 
 // rookCmd represents the rook command
 var RootCmd = &cobra.Command{
-	Use:   "rook-ceph",
-	Short: "kubectl rook-ceph provides common management and troubleshooting tools for Ceph.",
-	Args:  cobra.MinimumNArgs(1),
+	Use:              "rook-ceph",
+	Short:            "kubectl rook-ceph provides common management and troubleshooting tools for Ceph.",
+	Args:             cobra.MinimumNArgs(1),
+	TraverseChildren: true,
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		logging.Info("CephCluster namespace: %q", CephClusterNamespace)
+		logging.Info("Rook operator namespace: %q", OperatorNamespace)
+	},
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -50,7 +55,7 @@ func init() {
 
 	RootCmd.PersistentFlags().StringVar(&KubeConfig, "kubeconfig", "", "kubernetes config path")
 	RootCmd.PersistentFlags().StringVar(&OperatorNamespace, "operator-namespace", "rook-ceph", "Kubernetes namespace where rook operator is running")
-	RootCmd.PersistentFlags().StringVar(&CephClusterNamespace, "namespace", "rook-ceph", "Kubernetes namespace where ceph cluster is created")
+	RootCmd.PersistentFlags().StringVarP(&CephClusterNamespace, "namespace", "n", "rook-ceph", "Kubernetes namespace where CephCluster is created")
 }
 
 func GetClientsets() *k8sutil.Clientsets {

--- a/pkg/k8sutil/operator.go
+++ b/pkg/k8sutil/operator.go
@@ -40,10 +40,10 @@ func RestartDeployment(ctx context.Context, k8sclientset kubernetes.Interface, n
 	logging.Info("deployment.apps/%s restarted\n", deploymentName)
 }
 
-func WaitForPodToRun(ctx context.Context, k8sclientset kubernetes.Interface, operatorNamespace, labelSelector string) (corev1.Pod, error) {
+func WaitForPodToRun(ctx context.Context, k8sclientset kubernetes.Interface, namespace, labelSelector string) (corev1.Pod, error) {
 	opts := v1.ListOptions{LabelSelector: labelSelector}
 	for i := 0; i < 60; i++ {
-		pod, err := k8sclientset.CoreV1().Pods(operatorNamespace).List(ctx, opts)
+		pod, err := k8sclientset.CoreV1().Pods(namespace).List(ctx, opts)
 		if err != nil {
 			return corev1.Pod{}, fmt.Errorf("failed to list pods with labels matching %s", labelSelector)
 		}
@@ -53,7 +53,7 @@ func WaitForPodToRun(ctx context.Context, k8sclientset kubernetes.Interface, ope
 			}
 		}
 
-		logging.Info("waiting for pod to be running")
+		logging.Info("waiting for pod with label %q in namespace %q to be running", labelSelector, namespace)
 		time.Sleep(time.Second * 5)
 	}
 


### PR DESCRIPTION
Namespace flags should be parsed by the parent command and not by child
    commands. This poses a particular problem for the 'ceph' and 'rbd'
    commands, as they normally have flag parsing disabled. The parent
    command should use the cobra.Command option 'TraverseChildren' in order
    to parse parent args before parsing child commands.
    
This is built on top of #112