### PR TITLE
core: fix osd hang during purge-osd

### DIFF
--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -99,6 +99,7 @@ jobs:
       - name: Purge Osd
         run: |
           set -ex
+          kubectl -n rook-ceph scale deployment rook-ceph-osd-0 --replicas 0
           kubectl rook-ceph rook purge-osd 0 --force
 
       - name: collect common logs

--- a/cmd/commands/ceph.go
+++ b/cmd/commands/ceph.go
@@ -17,8 +17,6 @@ limitations under the License.
 package command
 
 import (
-	"fmt"
-
 	"github.com/rook/kubectl-rook-ceph/pkg/exec"
 	"github.com/rook/kubectl-rook-ceph/pkg/logging"
 	"github.com/spf13/cobra"
@@ -33,6 +31,6 @@ var CephCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		clientsets := GetClientsets()
 		logging.Info("running 'ceph' command with args: %v", args)
-		fmt.Println(exec.RunCommandInOperatorPod(cmd.Context(), clientsets, cmd.Use, args, OperatorNamespace, CephClusterNamespace, true))
+		exec.RunCommandInOperatorPod(cmd.Context(), clientsets, cmd.Use, args, OperatorNamespace, CephClusterNamespace, false, true)
 	},
 }

--- a/cmd/commands/rbd.go
+++ b/cmd/commands/rbd.go
@@ -17,8 +17,6 @@ limitations under the License.
 package command
 
 import (
-	"fmt"
-
 	"github.com/rook/kubectl-rook-ceph/pkg/exec"
 
 	"github.com/spf13/cobra"
@@ -32,6 +30,6 @@ var RbdCmd = &cobra.Command{
 	Args:               cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		clientsets := GetClientsets()
-		fmt.Println(exec.RunCommandInOperatorPod(cmd.Context(), clientsets, cmd.Use, args, OperatorNamespace, CephClusterNamespace, true))
+		exec.RunCommandInOperatorPod(cmd.Context(), clientsets, cmd.Use, args, OperatorNamespace, CephClusterNamespace, false, true)
 	},
 }

--- a/cmd/commands/rook.go
+++ b/cmd/commands/rook.go
@@ -17,8 +17,6 @@ limitations under the License.
 package command
 
 import (
-	"fmt"
-
 	"github.com/rook/kubectl-rook-ceph/pkg/exec"
 	"github.com/rook/kubectl-rook-ceph/pkg/rook"
 	"github.com/spf13/cobra"
@@ -37,7 +35,7 @@ var versionCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, _ []string) {
 		clientsets := GetClientsets()
-		fmt.Println(exec.RunCommandInOperatorPod(cmd.Context(), clientsets, "rook", []string{cmd.Use}, OperatorNamespace, CephClusterNamespace, true))
+		exec.RunCommandInOperatorPod(cmd.Context(), clientsets, "rook", []string{cmd.Use}, OperatorNamespace, CephClusterNamespace, false, true)
 	},
 }
 

--- a/pkg/dr/health.go
+++ b/pkg/dr/health.go
@@ -63,7 +63,7 @@ func Health(ctx context.Context, clientsets *k8sutil.Clientsets, operatorNamespa
 		cephArgs = append(cephArgs, args...)
 	}
 
-	cephStatus := exec.RunCommandInOperatorPod(ctx, clientsets, "ceph", cephArgs, operatorNamespace, cephClusterNamespace, false)
+	cephStatus := exec.RunCommandInOperatorPod(ctx, clientsets, "ceph", cephArgs, operatorNamespace, cephClusterNamespace, true, false)
 	if cephStatus == "" {
 		logging.Warning("failed to get ceph status from peer cluster, please check for network issues between the clusters")
 		return
@@ -72,7 +72,7 @@ func Health(ctx context.Context, clientsets *k8sutil.Clientsets, operatorNamespa
 
 	logging.Info("running mirroring daemon health")
 
-	fmt.Println(exec.RunCommandInOperatorPod(ctx, clientsets, "rbd", []string{"-p", mirrorBlockPool.Name, "mirror", "pool", "status"}, cephClusterNamespace, operatorNamespace, true))
+	exec.RunCommandInOperatorPod(ctx, clientsets, "rbd", []string{"-p", mirrorBlockPool.Name, "mirror", "pool", "status"}, cephClusterNamespace, operatorNamespace, false, false)
 }
 
 func extractSecretData(ctx context.Context, k8sclientset kubernetes.Interface, operatorNamespace, cephClusterNamespace, secretName string) (*secretData, error) {

--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -184,7 +184,7 @@ func checkMgrPodsStatusAndCounts(ctx context.Context, k8sclientset kubernetes.In
 }
 
 func unMarshalCephStatus(ctx context.Context, clientsets *k8sutil.Clientsets, operatorNamespace, clusterNamespace string) (string, []PgStateEntry) {
-	cephStatusOut := exec.RunCommandInOperatorPod(ctx, clientsets, "ceph", []string{"-s", "--format", "json"}, operatorNamespace, clusterNamespace, false)
+	cephStatusOut := exec.RunCommandInOperatorPod(ctx, clientsets, "ceph", []string{"-s", "--format", "json"}, operatorNamespace, clusterNamespace, true, false)
 
 	ecodedText := base64.StdEncoding.EncodeToString([]byte(cephStatusOut))
 	decodeCephStatus, err := base64.StdEncoding.DecodeString(ecodedText)

--- a/pkg/mons/restore_quorum.go
+++ b/pkg/mons/restore_quorum.go
@@ -191,27 +191,27 @@ func updateMonMap(ctx context.Context, clientsets *k8sutil.Clientsets, clusterNa
 	extractMonMapArgs := append(monMapArgs, extractMonMap...)
 
 	logging.Info("Extracting the monmap")
-	logging.Info(exec.RunCommandInLabeledPod(ctx, clientsets, labelSelector, "mon", "ceph-mon", extractMonMapArgs, clusterNamespace, true))
+	exec.RunCommandInLabeledPod(ctx, clientsets, labelSelector, "mon", "ceph-mon", extractMonMapArgs, clusterNamespace, false, true)
 
 	logging.Info("Printing monmap")
-	logging.Info(exec.RunCommandInLabeledPod(ctx, clientsets, labelSelector, "mon", "monmaptool", []string{"--print", monmapPath}, clusterNamespace, true))
+	exec.RunCommandInLabeledPod(ctx, clientsets, labelSelector, "mon", "monmaptool", []string{"--print", monmapPath}, clusterNamespace, false, true)
 
 	// remove all the mons except the good one
 	for _, badMonId := range badMons {
 		logging.Info("Removing mon %s.\n", badMonId)
-		logging.Info(exec.RunCommandInLabeledPod(ctx, clientsets, labelSelector, "mon", "monmaptool", []string{monmapPath, "--rm", badMonId}, clusterNamespace, true))
+		exec.RunCommandInLabeledPod(ctx, clientsets, labelSelector, "mon", "monmaptool", []string{monmapPath, "--rm", badMonId}, clusterNamespace, false, true)
 	}
 
 	injectMonMap := []string{fmt.Sprintf("--inject-monmap=%s", monmapPath)}
 	injectMonMapArgs := append(monMapArgs, injectMonMap...)
 
 	logging.Info("Injecting the monmap")
-	logging.Info(exec.RunCommandInLabeledPod(ctx, clientsets, labelSelector, "mon", "ceph-mon", injectMonMapArgs, clusterNamespace, true))
+	exec.RunCommandInLabeledPod(ctx, clientsets, labelSelector, "mon", "ceph-mon", injectMonMapArgs, clusterNamespace, false, true)
 
 	logging.Info("Finished updating the monmap!")
 
 	logging.Info("Printing final monmap")
-	logging.Info(exec.RunCommandInLabeledPod(ctx, clientsets, labelSelector, "mon", "monmaptool", []string{"--print", monmapPath}, clusterNamespace, true))
+	exec.RunCommandInLabeledPod(ctx, clientsets, labelSelector, "mon", "monmaptool", []string{"--print", monmapPath}, clusterNamespace, false, true)
 }
 
 func removeBadMonsResources(ctx context.Context, k8sclientset kubernetes.Interface, clusterNamespace string, badMons []string) error {
@@ -240,7 +240,7 @@ func waitForMonStatusResponse(ctx context.Context, clientsets *k8sutil.Clientset
 	maxRetries := 20
 
 	for i := 0; i < maxRetries; i++ {
-		output := exec.RunCommandInToolboxPod(ctx, clientsets, "ceph", []string{"status"}, clusterNamespace, false)
+		output := exec.RunCommandInToolboxPod(ctx, clientsets, "ceph", []string{"status"}, clusterNamespace, true, false)
 		if strings.Contains(output, "HEALTH_WARN") || strings.Contains(output, "HEALTH_OK") || strings.Contains(output, "HEALTH_ERROR") {
 			logging.Info("finished waiting for ceph status %s\n", output)
 			break

--- a/pkg/rook/purge_osd.go
+++ b/pkg/rook/purge_osd.go
@@ -20,14 +20,14 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/rook/kubectl-rook-ceph/pkg/exec"
+	exec "github.com/rook/kubectl-rook-ceph/pkg/exec"
 	"github.com/rook/kubectl-rook-ceph/pkg/k8sutil"
 	"github.com/rook/kubectl-rook-ceph/pkg/logging"
 	"github.com/rook/kubectl-rook-ceph/pkg/mons"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func PurgeOsd(ctx context.Context, clientsets *k8sutil.Clientsets, operatorNamespace, clusterNamespace, osdId, flag string) string {
+func PurgeOsd(ctx context.Context, clientsets *k8sutil.Clientsets, operatorNamespace, clusterNamespace, osdId, flag string) {
 	monCm, err := clientsets.Kube.CoreV1().ConfigMaps(clusterNamespace).Get(ctx, mons.MonConfigMap, v1.GetOptions{})
 	if err != nil {
 		logging.Fatal(fmt.Errorf("failed to get mon configmap %s %v", mons.MonConfigMap, err))
@@ -37,14 +37,18 @@ func PurgeOsd(ctx context.Context, clientsets *k8sutil.Clientsets, operatorNames
 	cephArgs := []string{
 		"auth", "print-key", "client.admin",
 	}
-	adminKey := exec.RunCommandInOperatorPod(ctx, clientsets, "ceph", cephArgs, operatorNamespace, clusterNamespace, true)
+
+	adminKey := exec.RunCommandInOperatorPod(ctx, clientsets, "ceph", cephArgs, operatorNamespace, clusterNamespace, true, false)
+	if adminKey == "" {
+		logging.Fatal(fmt.Errorf("failed to get ceph key"))
+	}
 
 	cmd := "/bin/sh"
 	args := []string{
 		"-c",
 		fmt.Sprintf("export ROOK_MON_ENDPOINTS=%s ROOK_CEPH_USERNAME=client.admin ROOK_CEPH_SECRET=%s ROOK_CONFIG_DIR=/var/lib/rook && rook ceph osd remove --osd-ids=%s --force-osd-removal=%s", monEndPoint, adminKey, osdId, flag),
 	}
-
 	logging.Info("Running purge osd command")
-	return exec.RunCommandInOperatorPod(ctx, clientsets, cmd, args, operatorNamespace, clusterNamespace, true)
+
+	exec.RunCommandInOperatorPod(ctx, clientsets, cmd, args, operatorNamespace, clusterNamespace, false, true)
 }


### PR DESCRIPTION
with earlier approach purging an OSD was hanging.
since, with bash implementation, it was passing so, this commit change the way osd removal command runs. Earlier, we were creating connection between the operator and then running the command now we are using os/exec package.

Signed-off-by: subhamkrai <srai@redhat.com>
fixes: #98