### PR TITLE
core: validate namespace before proceeding

### DIFF
--- a/cmd/commands/ceph.go
+++ b/cmd/commands/ceph.go
@@ -29,7 +29,7 @@ var CephCmd = &cobra.Command{
 	DisableFlagParsing: true,
 	Args:               cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		clientsets := GetClientsets()
+		clientsets := GetClientsets(cmd.Context())
 		logging.Info("running 'ceph' command with args: %v", args)
 		exec.RunCommandInOperatorPod(cmd.Context(), clientsets, cmd.Use, args, OperatorNamespace, CephClusterNamespace, false, true)
 	},

--- a/cmd/commands/debug.go
+++ b/cmd/commands/debug.go
@@ -34,7 +34,7 @@ var startDebugCmd = &cobra.Command{
 	Short: "Start debugging a deployment with an optional alternative ceph container image",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		clientsets := GetClientsets()
+		clientsets := GetClientsets(cmd.Context())
 		alternateImage := cmd.Flag("alternate-image").Value.String()
 		debug.StartDebug(cmd.Context(), clientsets.Kube, CephClusterNamespace, args[0], alternateImage)
 	},
@@ -45,7 +45,7 @@ var stopDebugCmd = &cobra.Command{
 	Short: "Stop debugging a deployment",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		clientsets := GetClientsets()
+		clientsets := GetClientsets(cmd.Context())
 		debug.StopDebug(cmd.Context(), clientsets.Kube, CephClusterNamespace, args[0])
 	},
 }

--- a/cmd/commands/dr_health.go
+++ b/cmd/commands/dr_health.go
@@ -18,7 +18,7 @@ var healthCmd = &cobra.Command{
 	DisableFlagParsing: true,
 	Args:               cobra.MaximumNArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
-		clientsets := GetClientsets()
+		clientsets := GetClientsets(cmd.Context())
 		dr.Health(cmd.Context(), clientsets, OperatorNamespace, CephClusterNamespace, args)
 	},
 }

--- a/cmd/commands/health.go
+++ b/cmd/commands/health.go
@@ -27,7 +27,7 @@ var Health = &cobra.Command{
 	DisableFlagParsing: true,
 	Args:               cobra.NoArgs,
 	Run: func(cmd *cobra.Command, _ []string) {
-		clientsets := GetClientsets()
+		clientsets := GetClientsets(cmd.Context())
 		health.Health(cmd.Context(), clientsets, OperatorNamespace, CephClusterNamespace)
 	},
 }

--- a/cmd/commands/mons.go
+++ b/cmd/commands/mons.go
@@ -32,7 +32,7 @@ var MonCmd = &cobra.Command{
 	Args:               cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
-			clientsets := GetClientsets()
+			clientsets := GetClientsets(cmd.Context())
 			fmt.Println(mons.GetMonEndpoint(cmd.Context(), clientsets.Kube, CephClusterNamespace))
 		}
 	},
@@ -45,7 +45,7 @@ var RestoreQuorum = &cobra.Command{
 	DisableFlagParsing: true,
 	Args:               cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		clientsets := GetClientsets()
+		clientsets := GetClientsets(cmd.Context())
 		mons.RestoreQuorum(cmd.Context(), clientsets, OperatorNamespace, CephClusterNamespace, args[0])
 	},
 }

--- a/cmd/commands/operator.go
+++ b/cmd/commands/operator.go
@@ -35,7 +35,7 @@ var restartCmd = &cobra.Command{
 	Short: "Restart rook-ceph-operator pod",
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		clientsets := GetClientsets()
+		clientsets := GetClientsets(cmd.Context())
 		k8sutil.RestartDeployment(cmd.Context(), clientsets.Kube, OperatorNamespace, "rook-ceph-operator")
 	},
 }
@@ -45,7 +45,7 @@ var setCmd = &cobra.Command{
 	Short: "Set the property in the rook-ceph-operator-config configmap.",
 	Args:  cobra.ExactArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
-		clientsets := GetClientsets()
+		clientsets := GetClientsets(cmd.Context())
 		k8sutil.UpdateConfigMap(cmd.Context(), clientsets.Kube, OperatorNamespace, "rook-ceph-operator-config", args[0], args[1])
 	},
 }

--- a/cmd/commands/rbd.go
+++ b/cmd/commands/rbd.go
@@ -29,7 +29,7 @@ var RbdCmd = &cobra.Command{
 	DisableFlagParsing: true,
 	Args:               cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		clientsets := GetClientsets()
+		clientsets := GetClientsets(cmd.Context())
 		exec.RunCommandInOperatorPod(cmd.Context(), clientsets, cmd.Use, args, OperatorNamespace, CephClusterNamespace, false, true)
 	},
 }

--- a/cmd/commands/rook.go
+++ b/cmd/commands/rook.go
@@ -34,7 +34,7 @@ var versionCmd = &cobra.Command{
 	Short: "Prints rook version",
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, _ []string) {
-		clientsets := GetClientsets()
+		clientsets := GetClientsets(cmd.Context())
 		exec.RunCommandInOperatorPod(cmd.Context(), clientsets, "rook", []string{cmd.Use}, OperatorNamespace, CephClusterNamespace, false, true)
 	},
 }
@@ -44,7 +44,7 @@ var purgeCmd = &cobra.Command{
 	Short: "Permanently remove an OSD from the cluster. Multiple OSDs can be removed with a comma-separated list of IDs.",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		clientsets := GetClientsets()
+		clientsets := GetClientsets(cmd.Context())
 		forceflagValue := cmd.Flag("force").Value.String()
 		osdID := args[0]
 		rook.PurgeOsd(cmd.Context(), clientsets, OperatorNamespace, CephClusterNamespace, osdID, forceflagValue)


### PR DESCRIPTION
core: validate namespace before proceeding
 
we should validate if namespaces exist or not
before running any commands.

core: throw a warning when an unsupported version of rook is used

this, commit throws warning when unsupported version of rook
is used for example if rook version contain alpha or beta,
it will throw warning.

fixes: https://github.com/rook/kubectl-rook-ceph/issues/110
    
 Signed-off-by: subhamkrai <srai@redhat.com>
