### PR TITLE
core: make rook version more readable

### DIFF
--- a/cmd/commands/root_test.go
+++ b/cmd/commands/root_test.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2023 The Rook Authors. All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package command
+
+import "testing"
+
+func Test_trimGoVersionFromRookVersion(t *testing.T) {
+	type args struct {
+		rookVersion string
+	}
+
+	sampleRookVersion := `rook: v1.11.0-alpha.0.420.gd9a17691c
+go: go1.19.10s`
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "trim go version from rook version",
+			args: args{rookVersion: sampleRookVersion},
+			want: "rook: v1.11.0-alpha.0.420.gd9a17691c",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := trimGoVersionFromRookVersion(tt.args.rookVersion); got != tt.want {
+				t.Errorf("trimGoVersionFromRookVersion() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -51,7 +51,6 @@ func RunCommandInOperatorPod(ctx context.Context, clientsets *k8sutil.Clientsets
 	if !returnOutput {
 		return ""
 	}
-	fmt.Println(stdout.String())
 
 	fmt.Print(stderr.String())
 	return stdout.String()


### PR DESCRIPTION
core: make rook version more readable

during pre-validation check, rook version was
printed in multiple lines with golang version
which was making it difficult to read. Now, it
prints in one single like with the golang version.

core: print version info only once
there was extra `fmt.Print()` in method `RunCommandInOperatorPod`
due to which command output was printed two times.

fixes: #118
Signed-off-by: subhamkrai <srai@redhat.com>