### PR TITLE
core: fix error when reading stdin

### DIFF
--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -125,7 +125,6 @@ func execCmdInPod(ctx context.Context, clientsets *k8sutil.Clientsets,
 		VersionedParams(&v1.PodExecOptions{
 			Container: containerName,
 			Command:   cmd,
-			Stdin:     true,
 			Stdout:    true,
 			Stderr:    true,
 			TTY:       false,
@@ -140,7 +139,6 @@ func execCmdInPod(ctx context.Context, clientsets *k8sutil.Clientsets,
 	if !returnOutput {
 		// Connect this process' std{in,out,err} to the remote shell process.
 		err = exec.StreamWithContext(ctx, remotecommand.StreamOptions{
-			Stdin:  os.Stdin,
 			Stdout: os.Stdout,
 			Stderr: os.Stderr,
 			Tty:    false,
@@ -155,7 +153,6 @@ func execCmdInPod(ctx context.Context, clientsets *k8sutil.Clientsets,
 	} else {
 		// Connect this process' std{in,out,err} to the remote shell process.
 		err = exec.StreamWithContext(ctx, remotecommand.StreamOptions{
-			Stdin:  os.Stdin,
 			Stdout: stdout,
 			Stderr: stderr,
 			Tty:    false,


### PR DESCRIPTION
there is no need to enabling stdin while
connecting with stream to rum the command inside
the pods. So, removing the `Stdin` field which makes it false.

fixes: #119 
Signed-off-by: subhamkrai <srai@redhat.com>