### PR TITLE
logs: Fix wording for debug pod

### DIFF
--- a/pkg/debug/start_debug.go
+++ b/pkg/debug/start_debug.go
@@ -104,7 +104,7 @@ func startDebug(ctx context.Context, k8sclientset kubernetes.Interface, clusterN
 		logging.Fatal(err)
 	}
 
-	logging.Info("Debug pod %s is ready use", pod.Name)
+	logging.Info("pod %s is ready for debugging", pod.Name)
 	return nil
 }
 


### PR DESCRIPTION
The output describe debug pod availability needed to be clarified