### PR TITLE
core: comment unnecessary namespace for now

### DIFF
--- a/cmd/commands/root.go
+++ b/cmd/commands/root.go
@@ -38,8 +38,8 @@ var RootCmd = &cobra.Command{
 	Args:             cobra.MinimumNArgs(1),
 	TraverseChildren: true,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		logging.Info("CephCluster namespace: %q", CephClusterNamespace)
-		logging.Info("Rook operator namespace: %q", OperatorNamespace)
+		// logging.Info("CephCluster namespace: %q", CephClusterNamespace)
+		// logging.Info("Rook operator namespace: %q", OperatorNamespace)
 	},
 }
 

--- a/pkg/logging/log.go
+++ b/pkg/logging/log.go
@@ -54,3 +54,4 @@ func Fatal(err error, args ...interface{}) {
 	fmt.Println()
 	os.Exit(1)
 }
+


### PR DESCRIPTION
core: comment unnecessary namespace for now

fixes: #118

