### PR TITLE
ci: add goreleaser to build the project

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: GoReleaser
+        uses: goreleaser/goreleaser-action@v1
+        with:
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       # krew-release-bot is a bot that automates the update of plugin manifests in krew-index when a new version of your kubectl plugin is released.
       # https://github.com/rajatjindal/krew-release-bot
       - name: Update new version in krew-index

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,28 @@
+before:
+  hooks:
+    - go mod tidy
+builds:
+  - id: kubectl-rook-ceph
+    main: ./cmd
+    binary: kubectl-rook-ceph
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
+
+archives:
+  - builds:
+      - kubectl-rook-ceph
+    name_template: "{{ .ProjectName }}_{{ .Tag }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+    wrap_in_directory: false
+    format: tar.gz
+    files:
+      - LICENSE


### PR DESCRIPTION
adding goreleaser to help in building the
project with different os and architecture.
Later, we'll use the artifact create from this
ci to pass it to krew release yaml.