### PR TITLE
remove-jq: add flag json to removing uses of jq tool

### DIFF
--- a/cmd/commands/rook.go
+++ b/cmd/commands/rook.go
@@ -17,10 +17,16 @@ limitations under the License.
 package command
 
 import (
+	"fmt"
+	"strconv"
+
 	"github.com/rook/kubectl-rook-ceph/pkg/exec"
+	"github.com/rook/kubectl-rook-ceph/pkg/logging"
 	"github.com/rook/kubectl-rook-ceph/pkg/rook"
 	"github.com/spf13/cobra"
 )
+
+var json bool
 
 // RookCmd represents the rook commands
 var RookCmd = &cobra.Command{
@@ -54,8 +60,13 @@ var purgeCmd = &cobra.Command{
 var statusCmd = &cobra.Command{
 	Use:   "status",
 	Short: "Print the phase and conditions of the CephCluster CR",
-	Run: func(_ *cobra.Command, args []string) {
-		rook.PrintCustomResourceStatus(CephClusterNamespace, args)
+	Run: func(cmd *cobra.Command, args []string) {
+		json := cmd.Flag("json").Value.String()
+		jsonValue, err := strconv.ParseBool(json)
+		if err != nil {
+			logging.Fatal(fmt.Errorf("failed to parse json flag: %v", err))
+		}
+		rook.PrintCustomResourceStatus(CephClusterNamespace, args, jsonValue)
 	},
 }
 
@@ -63,5 +74,6 @@ func init() {
 	RookCmd.AddCommand(versionCmd)
 	RookCmd.AddCommand(statusCmd)
 	RookCmd.AddCommand(purgeCmd)
+	statusCmd.PersistentFlags().Bool("json", false, "print status in json format")
 	purgeCmd.PersistentFlags().Bool("force", false, "force deletion of an OSD if the OSD still contains data")
 }


### PR DESCRIPTION
In some environment jq is not present by default
and the tool will through error. We are adding
flag `json` to print the rook status output in
json format otherwise it will simple.
example: without json.

```
./bin/kubectl-rook-ceph rook status cephcluster
Info: NAME         DATADIRHOSTPATH   MONCOUNT   AGE   PHASE   MESSAGE                        HEALTH        EXTERNAL   FSID
my-cluster   /var/lib/rook     1          15h   Ready   Cluster created successfully   HEALTH_WARN              cd10c270-c912-4e67-ab86-b4161df498d1
```

with json:
```
./bin/kubectl-rook-ceph rook status cephcluster --json
Info: {
    "apiVersion": "v1",
    "items": [
        {
            "apiVersion": "ceph.rook.io/v1",
            "kind": "CephCluster",
            "metadata": {
...
...
```

Fixes: #132 