### PR TITLE
add-auth: add auth plugin package

### DIFF
--- a/cmd/commands/root.go
+++ b/cmd/commands/root.go
@@ -29,6 +29,7 @@ import (
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8s "k8s.io/client-go/kubernetes"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/tools/clientcmd"
 )
 


### PR DESCRIPTION
some clusters may have some kind of kubectl authenticator example 'OIDC', `gcb`, etc. So adding the auth pkg will help.

Signed-off-by: subhamkrai <srai@redhat.com>

Fixes: #134 