### PR TITLE
flag: add context flag to switch between clusters

### DIFF
--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -47,6 +47,11 @@ jobs:
           set -ex
           kubectl rook-ceph ceph status
 
+      - name: Ceph status using context
+        run: |
+          set -ex
+          kubectl rook-ceph --context=$(kubectl config current-context) ceph status
+
       - name: Mon restore
         env:
           ROOK_PLUGIN_SKIP_PROMPTS: true
@@ -147,6 +152,11 @@ jobs:
         run: |
           set -ex
           kubectl rook-ceph --operator-namespace test-operator -n test-cluster ceph status
+
+      - name: Ceph status using context
+        run: |
+          set -ex
+          kubectl rook-ceph --operator-namespace test-operator -n test-cluster --context=$(kubectl config current-context) ceph status
 
       - name: Mon restore
         env:

--- a/cmd/commands/root.go
+++ b/cmd/commands/root.go
@@ -37,6 +37,7 @@ var (
 	KubeConfig           string
 	OperatorNamespace    string
 	CephClusterNamespace string
+	KubeContext          string
 )
 
 // rookCmd represents the rook command
@@ -67,6 +68,7 @@ func init() {
 	RootCmd.PersistentFlags().StringVar(&KubeConfig, "kubeconfig", "", "kubernetes config path")
 	RootCmd.PersistentFlags().StringVar(&OperatorNamespace, "operator-namespace", "", "Kubernetes namespace where rook operator is running")
 	RootCmd.PersistentFlags().StringVarP(&CephClusterNamespace, "namespace", "n", "rook-ceph", "Kubernetes namespace where CephCluster is created")
+	RootCmd.PersistentFlags().StringVar(&KubeContext, "context", "", "Kubernetes context to use")
 }
 
 func GetClientsets(ctx context.Context) *k8sutil.Clientsets {
@@ -74,10 +76,15 @@ func GetClientsets(ctx context.Context) *k8sutil.Clientsets {
 
 	clientsets := &k8sutil.Clientsets{}
 
+	congfigOverride := &clientcmd.ConfigOverrides{}
+	if KubeContext != "" {
+		congfigOverride = &clientcmd.ConfigOverrides{CurrentContext: KubeContext}
+	}
+
 	// 1. Create Kubernetes Client
 	kubeconfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
 		clientcmd.NewDefaultClientConfigLoadingRules(),
-		&clientcmd.ConfigOverrides{},
+		congfigOverride,
 	)
 
 	clientsets.KubeConfig, err = kubeconfig.ClientConfig()


### PR DESCRIPTION
we missed adding `--context` flag when migrating
to golang. Adding the flag back.

fixes: #136 