### PR TITLE
sample-cluster: create single simple node cluster

### DIFF
--- a/.github/workflows/single-node-cluster.yaml
+++ b/.github/workflows/single-node-cluster.yaml
@@ -1,0 +1,102 @@
+name: Single Node test
+on:
+  pull_request:
+
+defaults:
+  run:
+    # reference: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#using-a-specific-shell
+    shell: bash --noprofile --norc -eo pipefail -x {0}
+
+# cancel the in-progress workflow when PR is refreshed.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  create-cluster:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: setup golang
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.19
+
+      - name: setup minikube
+        uses: manusa/actions-setup-minikube@v2.4.2
+        with:
+          minikube version: "v1.23.2"
+          kubernetes version: "v1.22.2"
+          start args: --memory 6g --cpus=2
+          github token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: consider debugging
+        uses: mxschmitt/action-tmate@v3
+        with:
+          limit-access-to-actor: false
+          detached: true
+
+      - name: use local disk and create partitions for osds
+        run: |
+          tests/github-action-helper.sh use_local_disk
+          tests/github-action-helper.sh create_partitions_for_osds
+
+      - name: prepare loop devices for osds
+        run: |
+          tests/github-action-helper.sh prepare_loop_devices 1
+
+      - name: create cluster prerequisites
+        run: |
+          BLOCK=$(sudo lsblk --paths|awk '/14G/ {print $1}'| head -1)
+          tests/localPathPV.sh "$BLOCK"
+
+      - name: build the binary and run unit tests
+        run: |
+          make build
+          sudo cp bin/kubectl-rook-ceph /usr/local/bin/kubectl-rook_ceph
+          make test
+
+      - name: single node cluster
+        env:
+          CREATE_SINGLE_NODE_CEPH_CLUSTER: true
+        run: |
+          set -ex
+          kubectl rook-ceph create sample-cluster --storageclass=manual
+
+          # Wait for the operator pod to be ready
+          kubectl wait --for=condition=ready pod -l app=rook-ceph-operator -n rook-ceph --timeout=200s
+
+          timeout 200 bash <<-'EOF'
+            until [ $(kubectl get pod -l app=rook-ceph-osd-prepare -n rook-ceph -o jsonpath='{.items[*].metadata.name}' -o custom-columns=READY:status.containerStatuses[*].ready | grep -c true) -eq 1 ]; do
+              echo "waiting for the prepare pods to be in ready state"
+              sleep 1
+            done
+          EOF
+
+          timeout 200 bash <<-'EOF'
+            until [ $(kubectl get pod -l app=rook-ceph-osd -n rook-ceph -o jsonpath='{.items[*].metadata.name}' -o custom-columns=READY:status.containerStatuses[*].ready | grep -c true) -eq 1 ]; do
+              echo "waiting for the osd pods to be in ready state"
+              sleep 1
+            done
+          EOF
+
+          # Get the current count of pods in the rook-ceph namespace
+          currentCount=$(kubectl get pods -n rook-ceph --no-headers | wc -l)
+
+          # Check if the current count is equal to the desired count
+          if [ "$currentCount" -eq 9 ]; then
+              echo "Pod count in namespace rook-ceph is $currentCount, which is the desired count."
+          else
+              echo "Error: Pod count in namespace rook-ceph is $currentCount, but the desired count is 9."
+              exit 1
+          fi
+
+      - name: collect common logs
+        if: always()
+        uses: ./.github/workflows/collect-logs
+        with:
+          name: go-test

--- a/cmd/commands/ceph.go
+++ b/cmd/commands/ceph.go
@@ -29,7 +29,7 @@ var CephCmd = &cobra.Command{
 	DisableFlagParsing: true,
 	Args:               cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		clientsets := GetClientsets(cmd.Context())
+		clientsets := GetClientsets(cmd.Context(), true)
 		logging.Info("running 'ceph' command with args: %v", args)
 		exec.RunCommandInOperatorPod(cmd.Context(), clientsets, cmd.Use, args, OperatorNamespace, CephClusterNamespace, false, true)
 	},

--- a/cmd/commands/debug.go
+++ b/cmd/commands/debug.go
@@ -34,7 +34,7 @@ var startDebugCmd = &cobra.Command{
 	Short: "Start debugging a deployment with an optional alternative ceph container image",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		clientsets := GetClientsets(cmd.Context())
+		clientsets := GetClientsets(cmd.Context(), true)
 		alternateImage := cmd.Flag("alternate-image").Value.String()
 		debug.StartDebug(cmd.Context(), clientsets.Kube, CephClusterNamespace, args[0], alternateImage)
 	},
@@ -45,7 +45,7 @@ var stopDebugCmd = &cobra.Command{
 	Short: "Stop debugging a deployment",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		clientsets := GetClientsets(cmd.Context())
+		clientsets := GetClientsets(cmd.Context(), true)
 		debug.StopDebug(cmd.Context(), clientsets.Kube, CephClusterNamespace, args[0])
 	},
 }

--- a/cmd/commands/dr_health.go
+++ b/cmd/commands/dr_health.go
@@ -18,7 +18,7 @@ var healthCmd = &cobra.Command{
 	DisableFlagParsing: true,
 	Args:               cobra.MaximumNArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
-		clientsets := GetClientsets(cmd.Context())
+		clientsets := GetClientsets(cmd.Context(), true)
 		dr.Health(cmd.Context(), clientsets, OperatorNamespace, CephClusterNamespace, args)
 	},
 }

--- a/cmd/commands/health.go
+++ b/cmd/commands/health.go
@@ -27,7 +27,7 @@ var Health = &cobra.Command{
 	DisableFlagParsing: true,
 	Args:               cobra.NoArgs,
 	Run: func(cmd *cobra.Command, _ []string) {
-		clientsets := GetClientsets(cmd.Context())
+		clientsets := GetClientsets(cmd.Context(), true)
 		health.Health(cmd.Context(), clientsets, OperatorNamespace, CephClusterNamespace)
 	},
 }

--- a/cmd/commands/mons.go
+++ b/cmd/commands/mons.go
@@ -31,7 +31,7 @@ var MonCmd = &cobra.Command{
 	Args:               cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
-			clientsets := GetClientsets(cmd.Context())
+			clientsets := GetClientsets(cmd.Context(), true)
 			fmt.Println(mons.GetMonEndpoint(cmd.Context(), clientsets.Kube, CephClusterNamespace))
 		}
 	},
@@ -44,7 +44,7 @@ var RestoreQuorum = &cobra.Command{
 	DisableFlagParsing: true,
 	Args:               cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		clientsets := GetClientsets(cmd.Context())
+		clientsets := GetClientsets(cmd.Context(), true)
 		mons.RestoreQuorum(cmd.Context(), clientsets, OperatorNamespace, CephClusterNamespace, args[0])
 	},
 }

--- a/cmd/commands/operator.go
+++ b/cmd/commands/operator.go
@@ -34,7 +34,7 @@ var restartCmd = &cobra.Command{
 	Short: "Restart rook-ceph-operator pod",
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, _ []string) {
-		clientsets := GetClientsets(cmd.Context())
+		clientsets := GetClientsets(cmd.Context(), true)
 		k8sutil.RestartDeployment(cmd.Context(), clientsets.Kube, OperatorNamespace, "rook-ceph-operator")
 	},
 }
@@ -44,7 +44,7 @@ var setCmd = &cobra.Command{
 	Short: "Set the property in the rook-ceph-operator-config configmap.",
 	Args:  cobra.ExactArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
-		clientsets := GetClientsets(cmd.Context())
+		clientsets := GetClientsets(cmd.Context(), true)
 		k8sutil.UpdateConfigMap(cmd.Context(), clientsets.Kube, OperatorNamespace, "rook-ceph-operator-config", args[0], args[1])
 	},
 }

--- a/cmd/commands/rbd.go
+++ b/cmd/commands/rbd.go
@@ -28,7 +28,7 @@ var RbdCmd = &cobra.Command{
 	DisableFlagParsing: true,
 	Args:               cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		clientsets := GetClientsets(cmd.Context())
+		clientsets := GetClientsets(cmd.Context(), true)
 		exec.RunCommandInOperatorPod(cmd.Context(), clientsets, cmd.Use, args, OperatorNamespace, CephClusterNamespace, false, true)
 	},
 }

--- a/cmd/commands/rook.go
+++ b/cmd/commands/rook.go
@@ -40,7 +40,7 @@ var versionCmd = &cobra.Command{
 	Short: "Prints rook version",
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, _ []string) {
-		clientsets := GetClientsets(cmd.Context())
+		clientsets := GetClientsets(cmd.Context(), true)
 		exec.RunCommandInOperatorPod(cmd.Context(), clientsets, "rook", []string{cmd.Use}, OperatorNamespace, CephClusterNamespace, false, true)
 	},
 }
@@ -50,7 +50,7 @@ var purgeCmd = &cobra.Command{
 	Short: "Permanently remove an OSD from the cluster. Multiple OSDs can be removed with a comma-separated list of IDs.",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		clientsets := GetClientsets(cmd.Context())
+		clientsets := GetClientsets(cmd.Context(), true)
 		forceflagValue := cmd.Flag("force").Value.String()
 		osdID := args[0]
 		rook.PurgeOsd(cmd.Context(), clientsets, OperatorNamespace, CephClusterNamespace, osdID, forceflagValue)

--- a/cmd/commands/single_node.go
+++ b/cmd/commands/single_node.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2023 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package command
+
+import (
+	"fmt"
+
+	"github.com/rook/kubectl-rook-ceph/pkg/create"
+	"github.com/rook/kubectl-rook-ceph/pkg/logging"
+	"github.com/spf13/cobra"
+)
+
+var storageClassName string
+
+// CreateCmd represents the create command
+var CreateCmd = &cobra.Command{
+	Use:                "create",
+	Short:              "Create is the parent command for the sample-cluster",
+	DisableFlagParsing: true,
+	Args:               cobra.ExactArgs(1),
+}
+
+var sampleCmd = &cobra.Command{
+	Use:   "sample-cluster",
+	Short: "Create single node rook-ceph cluster",
+	Long: `
+	"kubectl rook-ceph create sample-cluster creates single node rook-ceph cluster based on the rook/ceph repo default examples configuration.
+
+	For pvc based cluster pass the flag '--storageclass=<name of the storageclass>'
+
+	Also,if you are creating this in minikube make sure to some minikube driver."
+	`,
+	Args: cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		clientsets := GetClientsets(cmd.Context(), false)
+		if storageClassName == "" {
+			logging.Fatal(fmt.Errorf("please pass the flag --storageclass=<name of the storageclass>"))
+		}
+		create.SampleCluster(cmd.Context(), clientsets, OperatorNamespace, CephClusterNamespace, storageClassName)
+	},
+}
+
+func init() {
+	CreateCmd.AddCommand(sampleCmd)
+	sampleCmd.Flags().StringVar(&storageClassName, "storageclass", "", "Name of the storageclass to be used for the cluster")
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -38,5 +38,6 @@ func addcommands() {
 		command.DebugCmd,
 		command.Health,
 		command.DrCmd,
+		command.CreateCmd,
 	)
 }

--- a/pkg/create/sample-cluster.go
+++ b/pkg/create/sample-cluster.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2023 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package create
+
+import (
+	"bytes"
+	"context"
+	_ "embed"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"text/template"
+
+	"github.com/rook/kubectl-rook-ceph/pkg/exec"
+	"github.com/rook/kubectl-rook-ceph/pkg/k8sutil"
+	"github.com/rook/kubectl-rook-ceph/pkg/logging"
+)
+
+type config struct {
+	ClusterNamespace string
+	StorageClassName string
+}
+
+var (
+	githubURL = "https://raw.githubusercontent.com/rook/rook/master/deploy/examples/"
+	//go:embed test-cluster-on-pvc.yaml
+	clusterYaml string
+)
+
+func SampleCluster(ctx context.Context, clientsets *k8sutil.Clientsets, operatorNamespace, clusterNamespace, storageClassName string) {
+	var answer, output string
+	logging.Warning(`
+	"This command will create a single-node Rook-Ceph cluster. We assume that you don't already have a Rook-Ceph cluster.
+	We also assume that you have a Kubernetes cluster and have read this https://rook.github.io/docs/rook/latest/Contributing/development-environment/ . Please type 'yes' to proceed."
+	`)
+
+	fmt.Scanf("%s", &answer)
+	output, err := printWarningMessage(answer)
+	if err != nil {
+		logging.Fatal(fmt.Errorf("Single node Rook-Ceph cluster creation aborted: %w", err))
+	}
+	logging.Info(output)
+
+	crdsYaml, err := getFileContentFromGitHub(githubURL, "crds.yaml", operatorNamespace, clusterNamespace)
+	if err != nil {
+		logging.Error(fmt.Errorf("Error fetching file crds.yaml: %v", err))
+		return
+	}
+	createK8sResources("crds.yaml", crdsYaml)
+
+	commonYaml, err := getFileContentFromGitHub(githubURL, "common.yaml", operatorNamespace, clusterNamespace)
+	if err != nil {
+		logging.Error(fmt.Errorf("Error fetching file common.yaml: %v", err))
+		return
+	}
+	createK8sResources("common.yaml", commonYaml)
+
+	operatorYaml, err := getFileContentFromGitHub(githubURL, "operator.yaml", operatorNamespace, clusterNamespace)
+	if err != nil {
+		logging.Error(fmt.Errorf("Error fetching file operator.yaml: %v", err))
+		return
+	}
+	createK8sResources("operator.yaml", operatorYaml)
+
+	c := &config{
+		ClusterNamespace: clusterNamespace,
+		StorageClassName: storageClassName,
+	}
+
+	t, err := loadTemplate("test-cluster-on-pvc.yaml", clusterYaml, c)
+	if err != nil {
+		logging.Error(err)
+	}
+	createK8sResources("cluster-test.yaml", t)
+}
+
+func loadTemplate(name, templateFileText string, config interface{}) ([]byte, error) {
+	var writer bytes.Buffer
+	t := template.New(name)
+	t, err := t.Parse(templateFileText)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse template %q: %w", name, err)
+	}
+	err = t.Execute(&writer, config)
+	return writer.Bytes(), err
+}
+
+func createK8sResources(fileName string, t []byte) {
+	// Create a temporary file
+	tempFile, err := os.CreateTemp("", fileName)
+	if err != nil {
+		logging.Fatal(err)
+	}
+
+	// Write the string content to the file
+	_, err = tempFile.WriteString(string(t))
+	if err != nil {
+		logging.Fatal(err)
+	}
+
+	// Close the file to ensure it's flushed to disk
+	err = tempFile.Close()
+	if err != nil {
+		logging.Fatal(err)
+	}
+
+	logging.Info(exec.ExecuteBashCommand("kubectl apply -f " + tempFile.Name()))
+}
+
+func getFileContentFromGitHub(url, fileName, operatorNamespace, clusterNamespace string) ([]byte, error) {
+	resp, err := http.Get(url + fileName)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to fetch file fileName %s, status code: %d", fileName, resp.StatusCode)
+	}
+
+	content, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	content = []byte(strings.ReplaceAll(string(content), "rook-ceph # namespace:operator", operatorNamespace+" # namespace:operator"))
+	content = []byte(strings.ReplaceAll(string(content), "rook-ceph # namespace:cluster", clusterNamespace+" # namespace:cluster"))
+	return content, nil
+}
+
+func printWarningMessage(answer string) (string, error) {
+	if skip, ok := os.LookupEnv("CREATE_SINGLE_NODE_CEPH_CLUSTER"); ok && skip == "true" {
+		return "skipped prompt since CREATE_SINGLE_NODE_CEPH_CLUSTER=true", nil
+	} else if answer == "yes" {
+		return "proceeding to create single node ceph cluster", nil
+	}
+
+	return "", fmt.Errorf("cancelled")
+}

--- a/pkg/create/test-cluster-on-pvc.yaml
+++ b/pkg/create/test-cluster-on-pvc.yaml
@@ -1,0 +1,52 @@
+apiVersion: ceph.rook.io/v1
+kind: CephCluster
+metadata:
+  name: rook-ceph
+  namespace: {{ .ClusterNamespace }} # namespace:cluster
+spec:
+  dataDirHostPath: /var/lib/rook
+  mon:
+    count: 1
+    volumeClaimTemplate:
+      spec:
+        storageClassName: {{ .StorageClassName }}
+        resources:
+          requests:
+            storage: 5Gi
+  cephVersion:
+    image: quay.io/ceph/ceph:v17.2.6
+  dashboard:
+    enabled: false
+  network:
+    hostNetwork: false
+  crashCollector:
+    disable: true
+  storage:
+    storageClassDeviceSets:
+      - name: set1
+        count: 1
+        portable: false
+        tuneDeviceClass: false
+        encrypted: false
+        volumeClaimTemplates:
+          - metadata:
+              name: data
+            spec:
+              resources:
+                requests:
+                  storage: 6Gi
+              storageClassName: {{ .StorageClassName }}
+              volumeMode: Block
+              accessModes:
+                - ReadWriteOnce
+---
+apiVersion: ceph.rook.io/v1
+kind: CephBlockPool
+metadata:
+  name: builtin-mgr
+  namespace: {{ .ClusterNamespace }} # namespace:cluster
+spec:
+  name: .mgr
+  replicated:
+    size: 1
+    requireSafeReplicaSize: false

--- a/tests/create-bluestore-partitions.sh
+++ b/tests/create-bluestore-partitions.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 The Rook Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+#############
+# VARIABLES #
+#############
+SIZE=2048M
+
+#############
+# FUNCTIONS #
+#############
+
+function usage {
+    echo "Use me like this to create bluestore partitions:"
+    echo "$0 --disk /dev/sda --bluestore-type block.db"
+    echo ""
+    echo "Use me like this to create multiple OSDs:"
+    echo "$0 --disk /dev/sda --osd-count 2"
+    echo ""
+}
+
+function wipe_disk {
+    sudo sgdisk --zap-all -- "$DISK"
+    sudo dd if=/dev/zero of="$DISK" bs=1M count=10
+    if [ -n "$WIPE_ONLY" ]; then
+        # `parted "$DISK -s print" exits with 1 if the partition label doesn't exist.
+        # It's no problem in "--wipe-only" mode
+        sudo parted "$DISK" -s print || :
+        return
+    fi
+    set +e
+    sudo parted -s "$DISK" mklabel gpt
+    set -e
+    sudo partprobe -d "$DISK"
+    sudo udevadm settle
+    sudo parted "$DISK" -s print
+}
+
+function create_partition {
+    sudo sgdisk --new=0:0:+"$SIZE" --change-name=0:"$1" --mbrtogpt -- "$DISK"
+}
+
+function create_block_partition {
+    local osd_count=$1
+    if [ "$osd_count" -eq 1 ]; then
+        sudo sgdisk --largest-new=0 --change-name=0:'block' --mbrtogpt -- "$DISK"
+    elif [ "$osd_count" -gt 1 ]; then
+        SIZE=6144M
+        for osd in $(seq 1 "$osd_count"); do
+            echo "$osd"
+            create_partition osd-"$osd"
+            echo "SUBSYSTEM==\"block\", ATTR{size}==\"12582912\", ATTR{partition}==\"$osd\", ACTION==\"add\", RUN+=\"/bin/chown 167:167 ${DISK}${osd}\"" | sudo tee -a /etc/udev/rules.d/01-rook-"$osd".rules
+        done
+    fi
+}
+
+########
+# MAIN #
+########
+if [ ! "$#" -ge 1 ]; then
+    exit 1
+fi
+
+while [ "$1" != "" ]; do
+    case $1 in
+    --disk)
+        shift
+        DISK="$1"
+        ;;
+    --bluestore-type)
+        shift
+        BLUESTORE_TYPE="$1"
+        ;;
+    --osd-count)
+        shift
+        OSD_COUNT="$1"
+        ;;
+    --wipe-only)
+        WIPE_ONLY=1
+        ;;
+    -h | --help)
+        usage
+        exit
+        ;;
+    *)
+        usage
+        exit 1
+        ;;
+    esac
+    shift
+done
+
+# First wipe the disk
+wipe_disk
+
+if [ -n "$WIPE_ONLY" ]; then
+    exit
+fi
+
+if [ -z "$WIPE_ONLY" ]; then
+    if [ -n "$BLUESTORE_TYPE" ]; then
+        case "$BLUESTORE_TYPE" in
+        block.db)
+            create_partition block.db
+            ;;
+        block.wal)
+            create_partition block.db
+            create_partition block.wal
+            ;;
+        *)
+            printf "invalid bluestore configuration %q" "$BLUESTORE_TYPE" >&2
+            exit 1
+            ;;
+        esac
+    fi
+
+    # Create final block partitions
+    create_block_partition "$OSD_COUNT"
+fi
+
+# Inform the kernel of partition table changes
+sudo partprobe "$DISK"
+
+# Wait the udev event queue, and exits if all current events are handled.
+sudo udevadm settle
+
+# Print drives
+sudo lsblk
+sudo parted "$DISK" -s print

--- a/tests/localPathPV.sh
+++ b/tests/localPathPV.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 The Rook Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+test_scratch_device=/dev/nvme0n1
+if [ $# -ge 1 ]; then
+  test_scratch_device=$1
+fi
+
+#############
+# VARIABLES #
+#############
+osd_count=2
+sudo lsblk
+sudo test ! -b "${test_scratch_device}" && echo "invalid scratch device, not a block device: ${test_scratch_device}" >&2 && exit 1
+
+#############
+# FUNCTIONS #
+#############
+
+function prepare_node() {
+  sudo rm -rf /var/lib/rook/rook-integration-test
+  sudo mkdir -p /var/lib/rook/rook-integration-test/mon1 /var/lib/rook/rook-integration-test/mon2 /var/lib/rook/rook-integration-test/mon3
+  node_name=$(kubectl get nodes -o jsonpath='{.items[*].metadata.name}')
+  kubectl label nodes "${node_name}" rook.io/has-disk=true
+  kubectl delete pv -l type=local
+}
+
+function create_mon_pvc() {
+  cat <<eof | kubectl apply -f -
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: local-vol1
+  labels:
+    type: local
+spec:
+  storageClassName: manual
+  capacity:
+    storage: 5Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  volumeMode: Filesystem
+  local:
+    path: "/var/lib/rook/rook-integration-test/mon1"
+  nodeAffinity:
+      required:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: rook.io/has-disk
+                operator: In
+                values:
+                - "true"
+eof
+}
+
+function create_osd_pvc() {
+  local osd_count=$1
+  local storage=6Gi
+
+  for osd in $(seq 1 "$osd_count"); do
+    path=${test_scratch_device}${osd}
+    if [ "$osd_count" -eq 1 ]; then
+      path=$test_scratch_device
+      storage=10Gi
+    fi
+
+    cat <<eof | kubectl apply -f -
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: local-vol$((4 + osd))
+  labels:
+    type: local
+spec:
+  storageClassName: manual
+  capacity:
+    storage: "$storage"
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  volumeMode: Block
+  local:
+    path: "$path"
+  nodeAffinity:
+      required:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: rook.io/has-disk
+                operator: In
+                values:
+                - "true"
+eof
+  done
+}
+
+function create_create_sc() {
+  cat <<eof | kubectl apply -f -
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: manual
+provisioner: kubernetes.io/no-provisioner
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Delete
+eof
+}
+
+########
+# MAIN #
+########
+prepare_node
+create_mon_pvc
+
+create_osd_pvc "$osd_count"
+create_create_sc
+
+kubectl get pv -o wide


### PR DESCRIPTION
this commit adds new command which will create
single node cluster based on configuration of
rook/ceph yaml files using go embed. This command
assumes that kubernetes cluster is already there.

- [x]  Complete CI testing

fixes: #95 