### PR TITLE
ci: update script to get right device filter

### DIFF
--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -121,6 +121,8 @@ jobs:
       - name: consider debugging
         if: failure()
         uses: mxschmitt/action-tmate@v3
+        with:
+          limit-access-to-actor: false
 
   custom-namespace:
     runs-on: ubuntu-20.04
@@ -227,3 +229,5 @@ jobs:
       - name: consider debugging
         if: failure()
         uses: mxschmitt/action-tmate@v3
+        with:
+          limit-access-to-actor: false


### PR DESCRIPTION
ci: update script to get right device filter
currently, deviceFilter was getting `/dev/sdb` instead
of `sdb` due to which osd is not getting created. Also,
modified few commands to clean disk before using.

ci: update tmate to disable limit access

Signed-off-by: subhamkrai <srai@redhat.com>