### PR TITLE
restore: restore crd after accidental deletion

### DIFF
--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -15,6 +15,8 @@ concurrency:
 jobs:
   default-namespace:
     runs-on: ubuntu-20.04
+    env:
+      ROOK_PLUGIN_SKIP_PROMPTS: true
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -53,8 +55,6 @@ jobs:
           kubectl rook-ceph --context=$(kubectl config current-context) ceph status
 
       - name: Mon restore
-        env:
-          ROOK_PLUGIN_SKIP_PROMPTS: true
         run: |
           set -ex
           # test the mon restore to restore to mon a, delete mons b and c, then add d and e
@@ -112,6 +112,22 @@ jobs:
           kubectl -n rook-ceph scale deployment rook-ceph-osd-0 --replicas 0
           kubectl rook-ceph rook purge-osd 0 --force
 
+      - name: Restore CRD without CRName
+        run: |
+          # First let's delete the cephCluster
+          kubectl -n rook-ceph delete cephcluster my-cluster --timeout 3s --wait=false
+
+          kubectl rook-ceph -n rook-ceph restore-deleted cephcluster
+          tests/github-action-helper.sh wait_for_crd_to_be_ready_default
+
+      - name: Restore CRD with CRName
+        run: |
+          # First let's delete the cephCluster
+          kubectl -n rook-ceph delete cephcluster my-cluster --timeout 3s --wait=false
+
+          kubectl rook-ceph -n rook-ceph restore-deleted cephcluster my-cluster
+          tests/github-action-helper.sh wait_for_crd_to_be_ready_default
+
       - name: collect common logs
         if: always()
         uses: ./.github/workflows/collect-logs
@@ -126,6 +142,8 @@ jobs:
 
   custom-namespace:
     runs-on: ubuntu-20.04
+    env:
+      ROOK_PLUGIN_SKIP_PROMPTS: true
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -166,8 +184,6 @@ jobs:
           kubectl rook-ceph --operator-namespace test-operator -n test-cluster --context=$(kubectl config current-context) ceph status
 
       - name: Mon restore
-        env:
-          ROOK_PLUGIN_SKIP_PROMPTS: true
         run: |
           set -ex
           # test the mon restore to restore to mon a, delete mons b and c, then add d and e
@@ -224,6 +240,22 @@ jobs:
           set -ex
           kubectl -n test-cluster scale deployment rook-ceph-osd-0 --replicas 0
           kubectl rook-ceph --operator-namespace test-operator -n test-cluster rook purge-osd 0 --force
+
+      - name: Restore CRD without CRName
+        run: |
+          # First let's delete the cephCluster
+          kubectl -n test-cluster delete cephcluster my-cluster --timeout 3s --wait=false
+
+          kubectl rook-ceph --operator-namespace test-operator -n test-cluster restore-deleted cephcluster
+          tests/github-action-helper.sh wait_for_crd_to_be_ready_custom
+
+      - name: Restore CRD with CRName
+        run: |
+          # First let's delete the cephCluster
+          kubectl -n test-cluster delete cephcluster my-cluster --timeout 3s --wait=false
+
+          kubectl rook-ceph --operator-namespace test-operator -n test-cluster restore-deleted cephcluster my-cluster
+          tests/github-action-helper.sh wait_for_crd_to_be_ready_custom
 
       - name: collect common logs
         if: always()

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ These are args currently supported:
 - `dr` :
   - `health [ceph status args]`: Print the `ceph status` of a peer cluster in a mirroring-enabled environment thereby validating connectivity between ceph clusters. Ceph status args can be optionally passed, such as to change the log level: `--debug-ms 1`.
 
+- `restore-deleted <CRD> [CRName]`: Restore the ceph resources which are stuck in deleting state due to underlying resources being present in the cluster
+
 - `help` : Output help text
 
 ## Documentation
@@ -101,6 +103,7 @@ Visit docs below for complete details about each command and their flags uses.
 1. [Debug OSDs and Mons](docs/debug.md)
 1. [Restore mon quorum](docs/mons.md#restore-quorum)
 1. [Disaster Recovery](docs/dr-health.md)
+1. [Restore deleted CRs](docs/crd.md)
 
 ## Examples
 

--- a/cmd/commands/restore.go
+++ b/cmd/commands/restore.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2023 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package command
+
+import (
+	"github.com/rook/kubectl-rook-ceph/pkg/restore"
+	"github.com/spf13/cobra"
+)
+
+// RestoreCmd represents the restore commands
+var RestoreCmd = &cobra.Command{
+	Use:   "restore-deleted",
+	Short: "Restores a CR that was accidentally deleted and is still in terminating state. Ex: restore cephcluster <my-cluster>",
+	Args:  cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		clientsets := GetClientsets(cmd.Context())
+		VerifyOperatorPodIsRunning(cmd.Context(), clientsets, OperatorNamespace, CephClusterNamespace)
+		restore.RestoreCrd(cmd.Context(), clientsets, OperatorNamespace, CephClusterNamespace, args)
+	},
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -38,5 +38,6 @@ func addcommands() {
 		command.DebugCmd,
 		command.Health,
 		command.DrCmd,
+		command.RestoreCmd,
 	)
 }

--- a/docs/crd.md
+++ b/docs/crd.md
@@ -1,0 +1,112 @@
+# Restoring Deleted CRs
+
+When a Rook CR is deleted, the Rook operator will respond to the deletion event to attempt to clean up the cluster resources. If any data is still present in the cluster, Rook will refuse to delete the CR to ensure data is not lost. The operator will refuse to remove the finalizer on the CR until the underlying data is deleted.
+
+While the underlying Ceph data and daemons continue to be available, the CRs will be stuck indefinitely in a Deleting state in which the operator will not continue to ensure cluster health. Upgrades will be blocked, further updates to the CRs are prevented, and so on. Since Kubernetes does not allow undeleting resources, the command below will allow repairing the CRs without even necessarily suffering cluster downtime.
+
+> [!NOTE]
+> If there are multiple deleted resources in the cluster and no specific resource is mentioned, the first resource will be restored. To restore all deleted resources, re-run the command multiple times.
+
+## restore-deleted Command
+
+The `restore-deleted` command has one required and one optional parameter:
+
+- `<CRD>`: The CRD type that is to be restored, such as CephCluster, CephFilesystem, CephBlockPool and so on.
+- `[CRName]`: The name of the specific CR which you want to restore since there can be multiple instances under the same CRD. For example, if there are multiple CephFilesystems stuck in deleting state, a specific filesystem can be restored: `restore-deleted cephfilesystem filesystem-2`.
+
+```bash
+kubectl rook-ceph restore-deleted <CRD> [CRName]
+```
+
+## CephCluster Restore Example
+
+```bash
+kubectl rook-ceph restore-deleted cephcluster
+
+Info: Detecting which resources to restore for crd "cephcluster"
+Info: Restoring CR my-cluster
+Warning: The resource my-cluster was found deleted. Do you want to restore it? yes | no
+
+Info: skipped prompt since ROOK_PLUGIN_SKIP_PROMPTS=true
+Info: Scaling down the operator to 0
+Info: Backing up kubernetes and crd resources
+Info: Backed up crd cephcluster/my-cluster in file cephcluster-my-cluster.yaml
+Info: Deleting validating webhook rook-ceph-webhook if present
+Info: Fetching the UID for cephcluster/my-cluster
+Info: Successfully fetched uid 8366f79a-ae1f-4679-a62b-8abc6e1528fa from cephcluster/my-cluster
+Info: Removing ownerreferences from resources with matching uid 8366f79a-ae1f-4679-a62b-8abc6e1528fa
+Info: Removing owner references for secret cluster-peer-token-my-cluster
+Info: Removed ownerReference for Secret: cluster-peer-token-my-cluster
+
+Info: Removing owner references for secret rook-ceph-admin-keyring
+Info: Removed ownerReference for Secret: rook-ceph-admin-keyring
+
+Info: Removing owner references for secret rook-ceph-config
+Info: Removed ownerReference for Secret: rook-ceph-config
+
+Info: Removing owner references for secret rook-ceph-crash-collector-keyring
+Info: Removed ownerReference for Secret: rook-ceph-crash-collector-keyring
+
+Info: Removing owner references for secret rook-ceph-mgr-a-keyring
+Info: Removed ownerReference for Secret: rook-ceph-mgr-a-keyring
+
+Info: Removing owner references for secret rook-ceph-mons-keyring
+Info: Removed ownerReference for Secret: rook-ceph-mons-keyring
+
+Info: Removing owner references for secret rook-csi-cephfs-node
+Info: Removed ownerReference for Secret: rook-csi-cephfs-node
+
+Info: Removing owner references for secret rook-csi-cephfs-provisioner
+Info: Removed ownerReference for Secret: rook-csi-cephfs-provisioner
+
+Info: Removing owner references for secret rook-csi-rbd-node
+Info: Removed ownerReference for Secret: rook-csi-rbd-node
+
+Info: Removing owner references for secret rook-csi-rbd-provisioner
+Info: Removed ownerReference for Secret: rook-csi-rbd-provisioner
+
+Info: Removing owner references for configmaps rook-ceph-mon-endpoints
+Info: Removed ownerReference for configmap: rook-ceph-mon-endpoints
+
+Info: Removing owner references for service rook-ceph-exporter
+Info: Removed ownerReference for service: rook-ceph-exporter
+
+Info: Removing owner references for service rook-ceph-mgr
+Info: Removed ownerReference for service: rook-ceph-mgr
+
+Info: Removing owner references for service rook-ceph-mgr-dashboard
+Info: Removed ownerReference for service: rook-ceph-mgr-dashboard
+
+Info: Removing owner references for service rook-ceph-mon-a
+Info: Removed ownerReference for service: rook-ceph-mon-a
+
+Info: Removing owner references for service rook-ceph-mon-d
+Info: Removed ownerReference for service: rook-ceph-mon-d
+
+Info: Removing owner references for service rook-ceph-mon-e
+Info: Removed ownerReference for service: rook-ceph-mon-e
+
+Info: Removing owner references for deployemt rook-ceph-mgr-a
+Info: Removed ownerReference for deployment: rook-ceph-mgr-a
+
+Info: Removing owner references for deployemt rook-ceph-mon-a
+Info: Removed ownerReference for deployment: rook-ceph-mon-a
+
+Info: Removing owner references for deployemt rook-ceph-mon-d
+Info: Removed ownerReference for deployment: rook-ceph-mon-d
+
+Info: Removing owner references for deployemt rook-ceph-mon-e
+Info: Removed ownerReference for deployment: rook-ceph-mon-e
+
+Info: Removing owner references for deployemt rook-ceph-osd-0
+Info: Removed ownerReference for deployment: rook-ceph-osd-0
+
+Info: Removing finalizers from cephcluster/my-cluster
+Info: cephcluster.ceph.rook.io/my-cluster patched
+
+Info: Re-creating the CR cephcluster from file cephcluster-my-cluster.yaml created above
+Info: cephcluster.ceph.rook.io/my-cluster created
+
+Info: Scaling up the operator to 1
+Info: CR is successfully restored. Please watch the operator logs and check the crd
+```

--- a/pkg/debug/start_debug.go
+++ b/pkg/debug/start_debug.go
@@ -25,7 +25,6 @@ import (
 	"github.com/rook/kubectl-rook-ceph/pkg/logging"
 
 	appsv1 "k8s.io/api/apps/v1"
-	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -39,7 +38,7 @@ func StartDebug(ctx context.Context, k8sclientset kubernetes.Interface, clusterN
 }
 
 func startDebug(ctx context.Context, k8sclientset kubernetes.Interface, clusterNamespace, deploymentName, alternateImageValue string) error {
-	originalDeployment, err := GetDeployment(ctx, k8sclientset, clusterNamespace, deploymentName)
+	originalDeployment, err := k8sutil.GetDeployment(ctx, k8sclientset, clusterNamespace, deploymentName)
 	if err != nil {
 		return fmt.Errorf("Missing mon or osd deployment name %s. %v\n", deploymentName, err)
 	}
@@ -69,7 +68,7 @@ func startDebug(ctx context.Context, k8sclientset kubernetes.Interface, clusterN
 		return err
 	}
 
-	if err := SetDeploymentScale(ctx, k8sclientset, clusterNamespace, deployment.Name, 0); err != nil {
+	if err := k8sutil.SetDeploymentScale(ctx, k8sclientset, clusterNamespace, deployment.Name, 0); err != nil {
 		return err
 	}
 
@@ -96,7 +95,7 @@ func startDebug(ctx context.Context, k8sclientset kubernetes.Interface, clusterN
 	}
 	logging.Info("ensure the debug deployment %s is scaled up\n", deploymentName)
 
-	if err := SetDeploymentScale(ctx, k8sclientset, clusterNamespace, debugDeployment.Name, 1); err != nil {
+	if err := k8sutil.SetDeploymentScale(ctx, k8sclientset, clusterNamespace, debugDeployment.Name, 1); err != nil {
 		return err
 	}
 
@@ -107,34 +106,6 @@ func startDebug(ctx context.Context, k8sclientset kubernetes.Interface, clusterN
 
 	logging.Info("pod %s is ready for debugging", pod.Name)
 	return nil
-}
-
-func SetDeploymentScale(ctx context.Context, k8sclientset kubernetes.Interface, namespace, deploymentName string, scaleCount int) error {
-	scale := &autoscalingv1.Scale{
-		ObjectMeta: v1.ObjectMeta{
-			Name:      deploymentName,
-			Namespace: namespace,
-		},
-		Spec: autoscalingv1.ScaleSpec{
-			Replicas: int32(scaleCount),
-		},
-	}
-	_, err := k8sclientset.AppsV1().Deployments(namespace).UpdateScale(ctx, deploymentName, scale, v1.UpdateOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to update scale of deployment %s. %v\n", deploymentName, err)
-	}
-	return nil
-}
-
-func GetDeployment(ctx context.Context, k8sclientset kubernetes.Interface, clusterNamespace, deploymentName string) (*appsv1.Deployment, error) {
-	logging.Info("fetching the deployment %s to be running\n", deploymentName)
-	deployment, err := k8sclientset.AppsV1().Deployments(clusterNamespace).Get(ctx, deploymentName, v1.GetOptions{})
-	if err != nil {
-		return nil, err
-	}
-
-	logging.Info("deployment %s exists\n", deploymentName)
-	return deployment, nil
 }
 
 func waitForPodDeletion(ctx context.Context, k8sclientset kubernetes.Interface, clusterNamespace, podName string) error {

--- a/pkg/debug/stop_debug.go
+++ b/pkg/debug/stop_debug.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/rook/kubectl-rook-ceph/pkg/k8sutil"
 	"github.com/rook/kubectl-rook-ceph/pkg/logging"
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -41,7 +42,7 @@ func stopDebug(ctx context.Context, k8sclientset kubernetes.Interface, clusterNa
 		deploymentName = deploymentName + "-debug"
 	}
 
-	debugDeployment, err := GetDeployment(ctx, k8sclientset, clusterNamespace, deploymentName)
+	debugDeployment, err := k8sutil.GetDeployment(ctx, k8sclientset, clusterNamespace, deploymentName)
 	if err != nil {
 		return fmt.Errorf("Missing mon or osd debug deployment name %s. %v\n", deploymentName, err)
 	}
@@ -53,7 +54,7 @@ func stopDebug(ctx context.Context, k8sclientset kubernetes.Interface, clusterNa
 	}
 
 	original_deployment_name := strings.ReplaceAll(deploymentName, "-debug", "")
-	if err := SetDeploymentScale(ctx, k8sclientset, clusterNamespace, original_deployment_name, 1); err != nil {
+	if err := k8sutil.SetDeploymentScale(ctx, k8sclientset, clusterNamespace, original_deployment_name, 1); err != nil {
 		return err
 	}
 	logging.Info("Successfully deleted debug deployment and restored deployment %q", original_deployment_name)

--- a/pkg/exec/bash.go
+++ b/pkg/exec/bash.go
@@ -17,6 +17,7 @@ limitations under the License.
 package exec
 
 import (
+	"os"
 	"os/exec"
 
 	"github.com/rook/kubectl-rook-ceph/pkg/logging"
@@ -24,12 +25,10 @@ import (
 
 func ExecuteBashCommand(command string) string {
 	cmd := exec.Command("/bin/bash",
-		"-x", // Print commands and their arguments as they are executed
-		"-e", // Exit immediately if a command exits with a non-zero status.
-		"-m", // Terminal job control, allows job to be terminated by SIGTERM
 		"-c", // Command to run
 		command,
 	)
+	cmd.Stderr = os.Stderr
 	stdout, err := cmd.Output()
 	if err != nil {
 		logging.Fatal(err)

--- a/pkg/restore/crd.go
+++ b/pkg/restore/crd.go
@@ -1,0 +1,229 @@
+/*
+Copyright 2023 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package restore
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/rook/kubectl-rook-ceph/pkg/exec"
+	"github.com/rook/kubectl-rook-ceph/pkg/k8sutil"
+	"github.com/rook/kubectl-rook-ceph/pkg/logging"
+	"github.com/rook/kubectl-rook-ceph/pkg/mons"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func RestoreCrd(ctx context.Context, k8sclientset *k8sutil.Clientsets, operatorNamespace, clusterNamespace string, args []string) {
+	crd := args[0]
+	logging.Info("Detecting which resources to restore for crd %q", crd)
+	getCrName := `kubectl -n %s get %s -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.metadata.deletionGracePeriodSeconds}{"\n"}{end}' | awk '$2=="0" {print $1}' | head -n 1`
+	command := fmt.Sprintf(getCrName, clusterNamespace, crd)
+	crName := strings.TrimSpace(exec.ExecuteBashCommand(command))
+
+	if crName == "" {
+		logging.Info("Nothing to do here, no %q resources in deleted state", crd)
+		return
+	}
+
+	if len(args) == 2 {
+		crName = args[1]
+	}
+
+	logging.Info("Restoring CR %s", crName)
+	var answer string
+	logging.Warning("The resource %s was found deleted. Do you want to restore it? yes | no\n", crName)
+	fmt.Scanf("%s", &answer)
+	err := mons.PromptToContinueOrCancel("restore-deleted", "yes", answer)
+	if err != nil {
+		logging.Fatal(fmt.Errorf("Restoring the resource %s cancelled", crName))
+	}
+	logging.Info("Proceeding with restoring deleting CR")
+
+	logging.Info("Scaling down the operator")
+	err = k8sutil.SetDeploymentScale(ctx, k8sclientset.Kube, operatorNamespace, "rook-ceph-operator", 0)
+	if err != nil {
+		deploy, er := k8sutil.GetDeployment(ctx, k8sclientset.Kube, operatorNamespace, "rook-ceph-operator")
+		if er != nil && !apierrors.IsNotFound(er) {
+			logging.Fatal(er)
+		}
+		if deploy.Status.ReadyReplicas != 0 {
+			logging.Fatal(fmt.Errorf("Failed to scale down the operator deployment. %v", err))
+		}
+	}
+
+	logging.Info("Backing up kubernetes and crd resources")
+	crFileName := crd + "-" + crName + ".yaml"
+	getCrYamlContent := `kubectl -n %s get %s %s -oyaml > %s`
+	command = fmt.Sprintf(getCrYamlContent, clusterNamespace, crd, crName, crFileName)
+	exec.ExecuteBashCommand(command)
+	logging.Info("Backed up crd %s/%s in file %s", crd, crName, crFileName)
+
+	webhookConfigName := "rook-ceph-webhook"
+	logging.Info("Deleting validating webhook %s if present", webhookConfigName)
+	err = k8sclientset.Kube.AdmissionregistrationV1().ValidatingWebhookConfigurations().Delete(ctx, webhookConfigName, v1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		logging.Fatal(fmt.Errorf("failed to delete validating webhook %s. %v", webhookConfigName, err))
+	}
+
+	logging.Info("Fetching the UID for %s/%s", crd, crName)
+	getCrUID := `kubectl -n %s get %s %s -o 'jsonpath={.metadata.uid}'`
+	command = fmt.Sprintf(getCrUID, clusterNamespace, crd, crName)
+	uid := exec.ExecuteBashCommand(command)
+	logging.Info("Successfully fetched uid %s from %s/%s", uid, crd, crName)
+
+	removeOwnerRefOfUID(ctx, k8sclientset, operatorNamespace, clusterNamespace, uid)
+
+	logging.Info("Removing finalizers from %s/%s", crd, crName)
+	removeFinalizers := `kubectl -n %s patch %s/%s --type json --patch='[ { "op": "remove", "path": "/metadata/finalizers" } ]'`
+	command = fmt.Sprintf(removeFinalizers, clusterNamespace, crd, crName)
+	logging.Info(exec.ExecuteBashCommand(command))
+
+	logging.Info("Re-creating the CR %s from file %s created above", crd, crFileName)
+	recreateCR := `kubectl create -f %s`
+	command = fmt.Sprintf(recreateCR, crFileName)
+	logging.Info(exec.ExecuteBashCommand(command))
+
+	logging.Info("Scaling up the operator")
+	err = k8sutil.SetDeploymentScale(ctx, k8sclientset.Kube, operatorNamespace, "rook-ceph-operator", 1)
+	if err != nil {
+		logging.Fatal(errors.Wrapf(err, "Operator pod still being scaled up"))
+	}
+
+	if err = os.Remove(crFileName); err != nil {
+		logging.Warning("Unable to remove. Please remove the file %s manually.%v", crFileName, err)
+	}
+
+	logging.Info("CR is successfully restored. Please watch the operator logs and check the crd")
+}
+
+func removeOwnerRefOfUID(ctx context.Context, k8sclientset *k8sutil.Clientsets, operatorNamespace, clusterNamespace, targetUID string) {
+	logging.Info("Removing ownerreferences from resources with matching uid %s", targetUID)
+
+	secrets, err := k8sclientset.Kube.CoreV1().Secrets(clusterNamespace).List(ctx, v1.ListOptions{})
+	if err != nil {
+		logging.Fatal(errors.Wrapf(err, "Failed to list secrets"))
+	}
+
+	for _, secret := range secrets.Items {
+		for _, owner := range secret.OwnerReferences {
+			if string(owner.UID) == targetUID {
+				logging.Info("Removing owner references for secret %s", secret.Name)
+				// Remove ownerReferences.
+				secret.OwnerReferences = nil
+
+				// Update the Secret without ownerReferences.
+				_, err := k8sclientset.Kube.CoreV1().Secrets(clusterNamespace).Update(ctx, &secret, v1.UpdateOptions{})
+				if err != nil {
+					logging.Fatal(errors.Wrapf(err, "Failed to update ownerReferences for secret %s", secret.Name))
+				}
+				logging.Info("Removed ownerReference for Secret: %s\n", secret.Name)
+			}
+		}
+	}
+
+	cms, err := k8sclientset.Kube.CoreV1().ConfigMaps(clusterNamespace).List(ctx, v1.ListOptions{})
+	if err != nil {
+		logging.Fatal(errors.Wrapf(err, "Failed to list configMaps"))
+	}
+
+	for _, cm := range cms.Items {
+		for _, owner := range cm.OwnerReferences {
+			if string(owner.UID) == targetUID {
+				logging.Info("Removing owner references for configmaps %s", cm.Name)
+				// Remove ownerReferences.
+				cm.OwnerReferences = nil
+
+				// Update the Secret without ownerReferences.
+				_, err := k8sclientset.Kube.CoreV1().ConfigMaps(clusterNamespace).Update(ctx, &cm, v1.UpdateOptions{})
+				if err != nil {
+					logging.Fatal(errors.Wrapf(err, "Failed to update ownerReferences for configmaps %s", cm.Name))
+				}
+				logging.Info("Removed ownerReference for configmap: %s\n", cm.Name)
+			}
+		}
+	}
+
+	services, err := k8sclientset.Kube.CoreV1().Services(clusterNamespace).List(ctx, v1.ListOptions{})
+	if err != nil {
+		logging.Fatal(errors.Wrapf(err, "Failed to list services"))
+	}
+
+	for _, service := range services.Items {
+		for _, owner := range service.OwnerReferences {
+			if string(owner.UID) == targetUID {
+				logging.Info("Removing owner references for service %s", service.Name)
+				// Remove ownerReferences.
+				service.OwnerReferences = nil
+
+				// Update the Secret without ownerReferences.
+				_, err := k8sclientset.Kube.CoreV1().Services(clusterNamespace).Update(ctx, &service, v1.UpdateOptions{})
+				if err != nil {
+					logging.Fatal(errors.Wrapf(err, "Failed to update ownerReferences for service %s", service.Name))
+				}
+				logging.Info("Removed ownerReference for service: %s\n", service.Name)
+			}
+		}
+	}
+
+	deploys, err := k8sclientset.Kube.AppsV1().Deployments(clusterNamespace).List(ctx, v1.ListOptions{})
+	if err != nil {
+		logging.Fatal(errors.Wrapf(err, "Failed to list deployments"))
+	}
+
+	for _, deploy := range deploys.Items {
+		for _, owner := range deploy.OwnerReferences {
+			if string(owner.UID) == targetUID {
+				logging.Info("Removing owner references for deployment %s", deploy.Name)
+				// Remove ownerReferences.
+				deploy.OwnerReferences = nil
+
+				// Update the Secret without ownerReferences.
+				_, err := k8sclientset.Kube.AppsV1().Deployments(clusterNamespace).Update(ctx, &deploy, v1.UpdateOptions{})
+				if err != nil {
+					logging.Fatal(errors.Wrapf(err, "Failed to update ownerReferences for deployemt %s", deploy.Name))
+				}
+				logging.Info("Removed ownerReference for deployment: %s\n", deploy.Name)
+			}
+		}
+	}
+
+	pvcs, err := k8sclientset.Kube.CoreV1().PersistentVolumeClaims(clusterNamespace).List(ctx, v1.ListOptions{})
+	if err != nil {
+		logging.Fatal(errors.Wrapf(err, "Failed to list pvc"))
+	}
+
+	for _, pvc := range pvcs.Items {
+		for _, owner := range pvc.OwnerReferences {
+			if string(owner.UID) == targetUID {
+				logging.Info("Removing owner references for pvc %s", pvc.Name)
+				// Remove ownerReferences.
+				pvc.OwnerReferences = nil
+
+				// Update the Secret without ownerReferences.
+				_, err := k8sclientset.Kube.CoreV1().PersistentVolumeClaims(clusterNamespace).Update(ctx, &pvc, v1.UpdateOptions{})
+				if err != nil {
+					logging.Fatal(errors.Wrapf(err, "Failed to update ownerReferences for pvc %s", pvc.Name))
+				}
+				logging.Info("Removed ownerReference for pvc: %s\n", pvc.Name)
+			}
+		}
+	}
+}

--- a/tests/github-action-helper.sh
+++ b/tests/github-action-helper.sh
@@ -41,6 +41,7 @@ deploy_rook() {
   sed -i '0,/count: 1/ s/count: 1/count: 3/' cluster-test.yaml
   kubectl create -f cluster-test.yaml
   wait_for_pod_to_be_ready_state_default
+  kubectl create -f https://raw.githubusercontent.com/rook/rook/master/deploy/examples/filesystem-test.yaml
   kubectl create -f https://raw.githubusercontent.com/rook/rook/master/deploy/examples/toolbox.yaml
   kubectl create -f https://raw.githubusercontent.com/rook/rook/master/deploy/examples/csi/rbd/storageclass-test.yaml
   kubectl create -f https://raw.githubusercontent.com/rook/rook/master/deploy/examples/csi/rbd/pvc.yaml
@@ -130,6 +131,24 @@ wait_for_deployment_to_be_running() {
   namespace=$2
   echo "Waiting for the pod from deployment \"$deployment\" to be running"
   kubectl -n "$namespace" wait deployment "$deployment" --for condition=Available=True --timeout=90s
+}
+
+wait_for_crd_to_be_ready_default() {
+  timeout 150 bash <<-'EOF'
+    until [ $(kubectl -n rook-ceph get cephcluster my-cluster -o=jsonpath='{.status.phase}') == "Ready" ]; do
+      echo "Waiting for the CephCluster my-cluster to be in the Ready state..."
+      sleep 2
+    done
+EOF
+}
+
+wait_for_crd_to_be_ready_custom() {
+  timeout 150 bash <<-'EOF'
+    until [ $(kubectl -n test-cluster get cephcluster my-cluster -o=jsonpath='{.status.phase}') == "Ready" ]; do
+      echo "Waiting for the CephCluster my-cluster to be in the Ready state..."
+      sleep 2
+    done
+EOF
 }
 
 ########


### PR DESCRIPTION
with these changes we'll be able to restore any
crd which stuck deletion due some dependencies
after after accidental deletion.
example:
kubectl rook-ceph -n <ns> restore <cr> <cr_name>

fixes: #68 