### PR TITLE
command: skip operator pod check when not required

### DIFF
--- a/cmd/commands/ceph.go
+++ b/cmd/commands/ceph.go
@@ -30,6 +30,7 @@ var CephCmd = &cobra.Command{
 	Args:               cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		clientsets := GetClientsets(cmd.Context())
+		VerifyOperatorPodIsRunning(cmd.Context(), clientsets, OperatorNamespace, CephClusterNamespace)
 		logging.Info("running 'ceph' command with args: %v", args)
 		exec.RunCommandInOperatorPod(cmd.Context(), clientsets, cmd.Use, args, OperatorNamespace, CephClusterNamespace, false, true)
 	},

--- a/cmd/commands/debug.go
+++ b/cmd/commands/debug.go
@@ -35,6 +35,7 @@ var startDebugCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		clientsets := GetClientsets(cmd.Context())
+		VerifyOperatorPodIsRunning(cmd.Context(), clientsets, OperatorNamespace, CephClusterNamespace)
 		alternateImage := cmd.Flag("alternate-image").Value.String()
 		debug.StartDebug(cmd.Context(), clientsets.Kube, CephClusterNamespace, args[0], alternateImage)
 	},
@@ -46,6 +47,7 @@ var stopDebugCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		clientsets := GetClientsets(cmd.Context())
+		VerifyOperatorPodIsRunning(cmd.Context(), clientsets, OperatorNamespace, CephClusterNamespace)
 		debug.StopDebug(cmd.Context(), clientsets.Kube, CephClusterNamespace, args[0])
 	},
 }

--- a/cmd/commands/dr_health.go
+++ b/cmd/commands/dr_health.go
@@ -19,6 +19,7 @@ var healthCmd = &cobra.Command{
 	Args:               cobra.MaximumNArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
 		clientsets := GetClientsets(cmd.Context())
+		VerifyOperatorPodIsRunning(cmd.Context(), clientsets, OperatorNamespace, CephClusterNamespace)
 		dr.Health(cmd.Context(), clientsets, OperatorNamespace, CephClusterNamespace, args)
 	},
 }

--- a/cmd/commands/health.go
+++ b/cmd/commands/health.go
@@ -28,6 +28,7 @@ var Health = &cobra.Command{
 	Args:               cobra.NoArgs,
 	Run: func(cmd *cobra.Command, _ []string) {
 		clientsets := GetClientsets(cmd.Context())
+		VerifyOperatorPodIsRunning(cmd.Context(), clientsets, OperatorNamespace, CephClusterNamespace)
 		health.Health(cmd.Context(), clientsets, OperatorNamespace, CephClusterNamespace)
 	},
 }

--- a/cmd/commands/operator.go
+++ b/cmd/commands/operator.go
@@ -35,6 +35,7 @@ var restartCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, _ []string) {
 		clientsets := GetClientsets(cmd.Context())
+		VerifyOperatorPodIsRunning(cmd.Context(), clientsets, OperatorNamespace, CephClusterNamespace)
 		k8sutil.RestartDeployment(cmd.Context(), clientsets.Kube, OperatorNamespace, "rook-ceph-operator")
 	},
 }

--- a/cmd/commands/rbd.go
+++ b/cmd/commands/rbd.go
@@ -29,6 +29,7 @@ var RbdCmd = &cobra.Command{
 	Args:               cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		clientsets := GetClientsets(cmd.Context())
+		VerifyOperatorPodIsRunning(cmd.Context(), clientsets, OperatorNamespace, CephClusterNamespace)
 		exec.RunCommandInOperatorPod(cmd.Context(), clientsets, cmd.Use, args, OperatorNamespace, CephClusterNamespace, false, true)
 	},
 }

--- a/cmd/commands/rook.go
+++ b/cmd/commands/rook.go
@@ -51,6 +51,7 @@ var purgeCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		clientsets := GetClientsets(cmd.Context())
+		VerifyOperatorPodIsRunning(cmd.Context(), clientsets, OperatorNamespace, CephClusterNamespace)
 		forceflagValue := cmd.Flag("force").Value.String()
 		osdID := args[0]
 		rook.PurgeOsd(cmd.Context(), clientsets, OperatorNamespace, CephClusterNamespace, osdID, forceflagValue)

--- a/cmd/commands/root.go
+++ b/cmd/commands/root.go
@@ -116,7 +116,9 @@ func PreValidationCheck(ctx context.Context, k8sclientset *k8sutil.Clientsets, o
 	if err != nil {
 		logging.Fatal(fmt.Errorf("CephCluster namespace '%s' does not exist. %v", cephClusterNamespace, err))
 	}
+}
 
+func VerifyOperatorPodIsRunning(ctx context.Context, k8sclientset *k8sutil.Clientsets, operatorNamespace, cephClusterNamespace string) {
 	rookVersionOutput := exec.RunCommandInOperatorPod(ctx, k8sclientset, "rook", []string{"version"}, operatorNamespace, cephClusterNamespace, true, false)
 	rookVersion := trimGoVersionFromRookVersion(rookVersionOutput)
 	if strings.Contains(rookVersion, "alpha") || strings.Contains(rookVersion, "beta") {


### PR DESCRIPTION
we should not be waiting or doing any operation realted to operator when it is not really required. Also, in some cases user may have intentionally scale down the operator. That's why we should skip doing operator operation when not required.