### PR TITLE
usages: Clear how to use purge-osd command

### DIFF
--- a/cmd/commands/rook.go
+++ b/cmd/commands/rook.go
@@ -47,7 +47,7 @@ var versionCmd = &cobra.Command{
 
 var purgeCmd = &cobra.Command{
 	Use:   "purge-osd",
-	Short: "Permanently remove an OSD from the cluster. Multiple OSDs can be removed with a comma-separated list of IDs.",
+	Short: "Permanently remove an OSD from the cluster. Multiple OSDs can be removed with a comma-separated list of IDs, for example, purge-osd 0,1",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		clientsets := GetClientsets(cmd.Context())


### PR DESCRIPTION
It was unclear in the help section of purge-osd
on how to remove multiple osd at once. So adding
an example command to remove multiple osd.

Fixes: #181