### PR TITLE
build: fix `make clean`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ build:
 	env GOOS=$(shell go env GOOS) GOARCH=$(shell go env GOARCH) go build -o bin/kubectl-rook-ceph  cmd/main.go
 
 clean:
-	rm kubectl-rook-ceph
+	@rm -f bin/kubectl-rook-ceph
 
 test:
 	@echo "running unit tests"


### PR DESCRIPTION
Signed-off-by: Michael Adam <obnox@samba.org>

`make clean` was broken because the rm command pointed to a non-existing file location.

This fixes this by using the correct path.