### PR TITLE
ci: filter both 14 and 64 disks in CI

### DIFF
--- a/tests/github-action-helper.sh
+++ b/tests/github-action-helper.sh
@@ -6,7 +6,7 @@ set -xeEo pipefail
 # VARIABLES #
 #############
 : "${FUNCTION:=${1}}"
-: "${BLOCK:=$(sudo lsblk --paths | awk '/14G/ {print $1}' | head -1)}"
+: "${BLOCK:=$(sudo lsblk --paths | awk '/14G/ || /64G/ {print $1}' | head -1)}"
 
 # source https://krew.sigs.k8s.io/docs/user-guide/setup/install/
 install_krew() {


### PR DESCRIPTION
github ci runner is allocating both 14 and 64 Gb disks to the setup. CI currently hard codes the lsblk with a 14G filter. This PR updates the filter to use either 14G or 64G disks.

<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] CI tests has been updated, if necessary.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
