### PR TITLE
osd: get ack from user before osd removal

### DIFF
--- a/pkg/mons/restore_quorum.go
+++ b/pkg/mons/restore_quorum.go
@@ -88,7 +88,7 @@ func restoreQuorum(ctx context.Context, clientsets *k8sutil.Clientsets, operator
 	var answer string
 	logging.Warning("Are you sure you want to restore the quorum to mon %s? If so, enter 'yes-really-restore'\n", goodMon)
 	fmt.Scanf("%s", &answer)
-	err = PromptToContinueOrCancel("restore-quorum", "yes-really-restore", answer)
+	err = PromptToContinueOrCancel("yes-really-restore", answer)
 	if err != nil {
 		return fmt.Errorf("restoring the mon quorum to mon %s cancelled", goodMon)
 	}
@@ -151,7 +151,7 @@ func restoreQuorum(ctx context.Context, clientsets *k8sutil.Clientsets, operator
 	logging.Info("Only a single mon is currently running")
 	logging.Info("Press Enter to start the operator and expand to full mon quorum again")
 
-	err = PromptToContinueOrCancel("restore-quorum", "yes-really-restore", answer)
+	err = PromptToContinueOrCancel("yes-really-restore", answer)
 	if err != nil {
 		return fmt.Errorf("skipping operator start to expand full mon quorum.")
 	}
@@ -279,7 +279,7 @@ func getMonDetails(goodMon string, monEndpoints []string) ([]string, string, str
 	return badMons, goodMonPublicIp, goodMonPort, nil
 }
 
-func PromptToContinueOrCancel(inputSource, expectedAnswer, answer string) error {
+func PromptToContinueOrCancel(expectedAnswer, answer string) error {
 	if skip, ok := os.LookupEnv("ROOK_PLUGIN_SKIP_PROMPTS"); ok && skip == "true" {
 		logging.Info("skipped prompt since ROOK_PLUGIN_SKIP_PROMPTS=true")
 		return nil

--- a/pkg/restore/crd.go
+++ b/pkg/restore/crd.go
@@ -51,7 +51,7 @@ func RestoreCrd(ctx context.Context, k8sclientset *k8sutil.Clientsets, operatorN
 	var answer string
 	logging.Warning("The resource %s was found deleted. Do you want to restore it? yes | no\n", crName)
 	fmt.Scanf("%s", &answer)
-	err := mons.PromptToContinueOrCancel("restore-deleted", "yes", answer)
+	err := mons.PromptToContinueOrCancel("yes", answer)
 	if err != nil {
 		logging.Fatal(fmt.Errorf("Restoring the resource %s cancelled", crName))
 	}


### PR DESCRIPTION
To avoid accidental removal of osd and making
sure user wants to remova the osd, adding changes
to get ack from user where user have to give ack
by writing `yes-i-really-mean-it`.

<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] CI tests has been updated, if necessary.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
