### PR TITLE
restore-crd: use dynamic api to get k8s resource

### DIFF
--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -130,7 +130,7 @@ jobs:
           # First let's delete the cephCluster
           kubectl -n rook-ceph delete cephcluster my-cluster --timeout 3s --wait=false
 
-          kubectl rook-ceph -n rook-ceph restore-deleted cephcluster
+          kubectl rook-ceph -n rook-ceph restore-deleted cephclusters
           tests/github-action-helper.sh wait_for_crd_to_be_ready_default
 
       - name: Restore CRD with CRName
@@ -138,7 +138,7 @@ jobs:
           # First let's delete the cephCluster
           kubectl -n rook-ceph delete cephcluster my-cluster --timeout 3s --wait=false
 
-          kubectl rook-ceph -n rook-ceph restore-deleted cephcluster my-cluster
+          kubectl rook-ceph -n rook-ceph restore-deleted cephclusters my-cluster
           tests/github-action-helper.sh wait_for_crd_to_be_ready_default
 
       - name: Show Cluster State
@@ -153,7 +153,7 @@ jobs:
           set -ex
           kubectl rook-ceph destroy-cluster
           sleep 1
-          kubectl get deployments -n rook-ceph --no-headers| wc -l | (read n && [ $n -le 1 ] || { echo "the crs could not be deleted"; exit 1;})        
+          kubectl get deployments -n rook-ceph --no-headers| wc -l | (read n && [ $n -le 1 ] || { echo "the crs could not be deleted"; exit 1;})
 
       - name: collect common logs
         if: always()
@@ -286,7 +286,7 @@ jobs:
           # First let's delete the cephCluster
           kubectl -n test-cluster delete cephcluster my-cluster --timeout 3s --wait=false
 
-          kubectl rook-ceph --operator-namespace test-operator -n test-cluster restore-deleted cephcluster
+          kubectl rook-ceph --operator-namespace test-operator -n test-cluster restore-deleted cephclusters
           tests/github-action-helper.sh wait_for_crd_to_be_ready_custom
 
       - name: Restore CRD with CRName
@@ -294,7 +294,7 @@ jobs:
           # First let's delete the cephCluster
           kubectl -n test-cluster delete cephcluster my-cluster --timeout 3s --wait=false
 
-          kubectl rook-ceph --operator-namespace test-operator -n test-cluster restore-deleted cephcluster my-cluster
+          kubectl rook-ceph --operator-namespace test-operator -n test-cluster restore-deleted cephclusters my-cluster
           tests/github-action-helper.sh wait_for_crd_to_be_ready_custom
 
       - name: Show Cluster State

--- a/cmd/commands/root.go
+++ b/cmd/commands/root.go
@@ -21,8 +21,6 @@ import (
 	"regexp"
 	"strings"
 
-	"k8s.io/client-go/dynamic"
-
 	"github.com/rook/kubectl-rook-ceph/pkg/exec"
 	"github.com/rook/kubectl-rook-ceph/pkg/k8sutil"
 	"github.com/rook/kubectl-rook-ceph/pkg/logging"
@@ -30,6 +28,7 @@ import (
 	"github.com/spf13/cobra"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
 	k8s "k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/tools/clientcmd"

--- a/docs/crd.md
+++ b/docs/crd.md
@@ -11,102 +11,43 @@ While the underlying Ceph data and daemons continue to be available, the CRs wil
 
 The `restore-deleted` command has one required and one optional parameter:
 
-- `<CRD>`: The CRD type that is to be restored, such as CephCluster, CephFilesystem, CephBlockPool and so on.
-- `[CRName]`: The name of the specific CR which you want to restore since there can be multiple instances under the same CRD. For example, if there are multiple CephFilesystems stuck in deleting state, a specific filesystem can be restored: `restore-deleted cephfilesystem filesystem-2`.
+- `<CRD>`: The CRD type that is to be restored, such as CephClusters, CephFilesystems, CephBlockPools and so on.
+- `[CRName]`: The name of the specific CR which you want to restore since there can be multiple instances under the same CRD. For example, if there are multiple CephFilesystems stuck in deleting state, a specific filesystem can be restored: `restore-deleted cephfilesystems filesystem-2`.
 
 ```bash
 kubectl rook-ceph restore-deleted <CRD> [CRName]
 ```
 
-## CephCluster Restore Example
+## CephClusters Restore Example
 
 ```bash
-kubectl rook-ceph restore-deleted cephcluster
+kubectl rook-ceph restore-deleted cephclusters
 
-Info: Detecting which resources to restore for crd "cephcluster"
+Info: Detecting which resources to restore for crd "cephclusters"
+
 Info: Restoring CR my-cluster
 Warning: The resource my-cluster was found deleted. Do you want to restore it? yes | no
 
 Info: skipped prompt since ROOK_PLUGIN_SKIP_PROMPTS=true
-Info: Scaling down the operator to 0
-Info: Backing up kubernetes and crd resources
-Info: Backed up crd cephcluster/my-cluster in file cephcluster-my-cluster.yaml
+Info: Proceeding with restoring deleting CR
+Info: Scaling down the operator
 Info: Deleting validating webhook rook-ceph-webhook if present
-Info: Fetching the UID for cephcluster/my-cluster
-Info: Successfully fetched uid 8366f79a-ae1f-4679-a62b-8abc6e1528fa from cephcluster/my-cluster
-Info: Removing ownerreferences from resources with matching uid 8366f79a-ae1f-4679-a62b-8abc6e1528fa
+Info: Removing ownerreferences from resources with matching uid 92c0e549-44fd-43db-80ba-5473db996208
 Info: Removing owner references for secret cluster-peer-token-my-cluster
 Info: Removed ownerReference for Secret: cluster-peer-token-my-cluster
 
 Info: Removing owner references for secret rook-ceph-admin-keyring
 Info: Removed ownerReference for Secret: rook-ceph-admin-keyring
 
-Info: Removing owner references for secret rook-ceph-config
-Info: Removed ownerReference for Secret: rook-ceph-config
+---
+---
+---
 
-Info: Removing owner references for secret rook-ceph-crash-collector-keyring
-Info: Removed ownerReference for Secret: rook-ceph-crash-collector-keyring
-
-Info: Removing owner references for secret rook-ceph-mgr-a-keyring
-Info: Removed ownerReference for Secret: rook-ceph-mgr-a-keyring
-
-Info: Removing owner references for secret rook-ceph-mons-keyring
-Info: Removed ownerReference for Secret: rook-ceph-mons-keyring
-
-Info: Removing owner references for secret rook-csi-cephfs-node
-Info: Removed ownerReference for Secret: rook-csi-cephfs-node
-
-Info: Removing owner references for secret rook-csi-cephfs-provisioner
-Info: Removed ownerReference for Secret: rook-csi-cephfs-provisioner
-
-Info: Removing owner references for secret rook-csi-rbd-node
-Info: Removed ownerReference for Secret: rook-csi-rbd-node
-
-Info: Removing owner references for secret rook-csi-rbd-provisioner
-Info: Removed ownerReference for Secret: rook-csi-rbd-provisioner
-
-Info: Removing owner references for configmaps rook-ceph-mon-endpoints
-Info: Removed ownerReference for configmap: rook-ceph-mon-endpoints
-
-Info: Removing owner references for service rook-ceph-exporter
-Info: Removed ownerReference for service: rook-ceph-exporter
-
-Info: Removing owner references for service rook-ceph-mgr
-Info: Removed ownerReference for service: rook-ceph-mgr
-
-Info: Removing owner references for service rook-ceph-mgr-dashboard
-Info: Removed ownerReference for service: rook-ceph-mgr-dashboard
-
-Info: Removing owner references for service rook-ceph-mon-a
-Info: Removed ownerReference for service: rook-ceph-mon-a
-
-Info: Removing owner references for service rook-ceph-mon-d
-Info: Removed ownerReference for service: rook-ceph-mon-d
-
-Info: Removing owner references for service rook-ceph-mon-e
-Info: Removed ownerReference for service: rook-ceph-mon-e
-
-Info: Removing owner references for deployemt rook-ceph-mgr-a
-Info: Removed ownerReference for deployment: rook-ceph-mgr-a
-
-Info: Removing owner references for deployemt rook-ceph-mon-a
-Info: Removed ownerReference for deployment: rook-ceph-mon-a
-
-Info: Removing owner references for deployemt rook-ceph-mon-d
-Info: Removed ownerReference for deployment: rook-ceph-mon-d
-
-Info: Removing owner references for deployemt rook-ceph-mon-e
-Info: Removed ownerReference for deployment: rook-ceph-mon-e
-
-Info: Removing owner references for deployemt rook-ceph-osd-0
+Info: Removing owner references for deployment rook-ceph-osd-0
 Info: Removed ownerReference for deployment: rook-ceph-osd-0
 
-Info: Removing finalizers from cephcluster/my-cluster
-Info: cephcluster.ceph.rook.io/my-cluster patched
-
-Info: Re-creating the CR cephcluster from file cephcluster-my-cluster.yaml created above
-Info: cephcluster.ceph.rook.io/my-cluster created
-
-Info: Scaling up the operator to 1
+Info: Removing finalizers from cephclusters/my-cluster
+Info: Re-creating the CR cephclusters from dynamic resource
+Info: Scaling up the operator
 Info: CR is successfully restored. Please watch the operator logs and check the crd
 ```

--- a/pkg/k8sutil/dynamic.go
+++ b/pkg/k8sutil/dynamic.go
@@ -18,6 +18,7 @@ package k8sutil
 
 import (
 	"context"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -112,6 +113,30 @@ func (c *Clientsets) GetResourcesDynamically(
 
 	item, err := c.Dynamic.Resource(resourceId).Namespace(namespace).
 		Get(ctx, name, metav1.GetOptions{})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return item, nil
+}
+
+func (c *Clientsets) CreateResourcesDynamically(
+	ctx context.Context,
+	group string,
+	version string,
+	resource string,
+	name *unstructured.Unstructured,
+	namespace string,
+) (*unstructured.Unstructured, error) {
+	resourceId := schema.GroupVersionResource{
+		Group:    group,
+		Version:  version,
+		Resource: resource,
+	}
+
+	item, err := c.Dynamic.Resource(resourceId).Namespace(namespace).
+		Create(ctx, name, metav1.CreateOptions{})
 
 	if err != nil {
 		return nil, err

--- a/pkg/k8sutil/interface.go
+++ b/pkg/k8sutil/interface.go
@@ -18,12 +18,14 @@ package k8sutil
 
 import (
 	"context"
+
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 )
 
 //go:generate mockgen -package=k8sutil --build_flags=--mod=mod -destination=mocks.go github.com/rook/kubectl-rook-ceph/pkg/k8sutil ClientsetsInterface
 type ClientsetsInterface interface {
+	CreateResourcesDynamically(ctx context.Context, group string, version string, resource string, name *unstructured.Unstructured, namespace string) (*unstructured.Unstructured, error)
 	ListResourcesDynamically(ctx context.Context, group string, version string, resource string, namespace string) ([]unstructured.Unstructured, error)
 	GetResourcesDynamically(ctx context.Context, group string, version string, resource string, name string, namespace string) (*unstructured.Unstructured, error)
 	DeleteResourcesDynamically(ctx context.Context, group string, version string, resource string, namespace string, resourceName string) error

--- a/pkg/k8sutil/mocks.go
+++ b/pkg/k8sutil/mocks.go
@@ -36,6 +36,21 @@ func (m *MockClientsetsInterface) EXPECT() *MockClientsetsInterfaceMockRecorder 
 	return m.recorder
 }
 
+// CreateResourcesDynamically mocks base method.
+func (m *MockClientsetsInterface) CreateResourcesDynamically(arg0 context.Context, arg1, arg2, arg3 string, arg4 *unstructured.Unstructured, arg5 string) (*unstructured.Unstructured, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateResourcesDynamically", arg0, arg1, arg2, arg3, arg4, arg5)
+	ret0, _ := ret[0].(*unstructured.Unstructured)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateResourcesDynamically indicates an expected call of CreateResourcesDynamically.
+func (mr *MockClientsetsInterfaceMockRecorder) CreateResourcesDynamically(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateResourcesDynamically", reflect.TypeOf((*MockClientsetsInterface)(nil).CreateResourcesDynamically), arg0, arg1, arg2, arg3, arg4, arg5)
+}
+
 // DeleteResourcesDynamically mocks base method.
 func (m *MockClientsetsInterface) DeleteResourcesDynamically(arg0 context.Context, arg1, arg2, arg3, arg4, arg5 string) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**
currently, we are directly using `kubectl` command to get crds, crd name and also for other ops. Since, we now have code to get k8s resource using dynamic api, let's use that instead of `kubectl` command.

One thing to notice, now it more restrict when passing the ceph crd
types. For example, earlier `cephcluster` used to work now we need to be
specific `cephclusters`.


**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] CI tests has been updated, if necessary.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
