### PR TITLE
status: using dynamic api instead of kubectl

### DIFF
--- a/cmd/commands/rook.go
+++ b/cmd/commands/rook.go
@@ -67,12 +67,7 @@ var statusCmd = &cobra.Command{
 	Args:    cobra.MaximumNArgs(1),
 	Example: "kubectl rook-ceph rook status [CR_Name]",
 	Run: func(cmd *cobra.Command, args []string) {
-		json := cmd.Flag("json").Value.String()
-		jsonValue, err := strconv.ParseBool(json)
-		if err != nil {
-			logging.Fatal(fmt.Errorf("failed to parse json flag: %v", err))
-		}
-		rook.PrintCustomResourceStatus(cephClusterNamespace, args, jsonValue)
+		rook.PrintCustomResourceStatus(cmd.Context(), clientSets, cephClusterNamespace, args)
 	},
 }
 

--- a/docs/rook.md
+++ b/docs/rook.md
@@ -2,20 +2,19 @@
 
 The `rook` command supports the following sub-commands:
 
-1. `purge-osd <osd-id> [--force]` : [purge osd](#purge-osd) permanently remove an OSD from the cluster. Multiple OSDs can be removed in a single command with a comma-separated list of IDs.
+1. `purge-osd <osd-id> [--force]` : [purge osd](#purge-an-osd) permanently remove an OSD from the cluster. Multiple OSDs can be removed in a single command with a comma-separated list of IDs.
 2. `version`: [version](#version) prints the rook version.
-3. `status`      : [status](#status) print the phase and conditions of the CephCluster CR
-4. `status all`  : [status all](#status-all) print the phase and conditions of all CRs
-5. `status <CR>` : [status  cr](#status-cr-name) print the phase and conditions of CRs of a specific type, such as 'cephobjectstore', 'cephfilesystem', etc
+3. `status`: [status](#status) print the phase and conditions of the CephCluster CR
+4. `status all`: [status all](#status-all) print the phase and conditions of all CRs
+5. `status <CR>`: [status  cr](#status-cr-name) print the phase and conditions of CRs of a specific type, such as 'cephobjectstore', 'cephfilesystem', etc
 
 ## Purge an OSD
 
-Permanently remove an OSD from the cluster. 
-
+Permanently remove an OSD from the cluster.
 
 !!! warning
     Data loss is possible when passing the --force flag if the PGs are not healthy on other OSDs.
-    
+
 ```bash
 kubectl rook-ceph rook purge-osd 0 --force
 
@@ -46,123 +45,141 @@ kubectl rook-ceph rook version
 ```bash
 kubectl rook-ceph rook status
 
-# "ceph": {
-#     "capacity": {},
-#     "fsid": "b74c18dd-6ee3-44fe-90b5-ed12feac46a4",
-#     "health": "HEALTH_OK",
-#     "lastChecked": "2022-09-14T08:57:00Z",
-#     "versions": {
-#       "mgr": {
-#         "ceph version 17.2.3 (dff484dfc9e19a9819f375586300b3b79d80034d) quincy (stable)": 1
-#       },
-#       "mon": {
-#         "ceph version 17.2.3 (dff484dfc9e19a9819f375586300b3b79d80034d) quincy (stable)": 3
-#       },
-#       "overall": {
-#         "ceph version 17.2.3 (dff484dfc9e19a9819f375586300b3b79d80034d) quincy (stable)": 4
-#       }
-#     }
-#   },
-#   "conditions": [
-#     {
-#       "lastHeartbeatTime": "2022-09-14T08:57:02Z",
-#       "lastTransitionTime": "2022-09-14T08:56:59Z",
-#       "message": "Cluster created successfully",
-#       "reason": "ClusterCreated",
-#       "status": "True",
-#       "type": "Ready"
-#     },
-#     {
-#       "lastHeartbeatTime": "2022-09-14T08:57:30Z",
-#       "lastTransitionTime": "2022-09-14T08:57:30Z",
-#       "message": "Detecting Ceph version",
-#       "reason": "ClusterProgressing",
-#       "status": "True",
-#       "type": "Progressing"
-#     }
-#   ],
-#   "message": "Detecting Ceph version",
-#   "observedGeneration": 2,
-#   "phase": "Progressing",
-#   "state": "Creating",
-#   "version": {
-#     "image": "quay.io/ceph/ceph:v17",
-#     "version": "17.2.3-0"
-#   }
+# Info: cephclusters my-cluster
+# ceph:
+#   capacity:
+#     bytesAvailable: 20942778368
+#     bytesTotal: 20971520000
+#     bytesUsed: 28741632
+#     lastUpdated: "2024-01-11T06:43:27Z"
+#   fsid: 5a8dc97a-1d21-4c0e-aac2-fdc924e18374
+#   health: HEALTH_OK
+#   lastChanged: "2024-01-11T05:38:27Z"
+#   lastChecked: "2024-01-11T06:43:27Z"
+#   previousHealth: HEALTH_ERR
+#   versions:
+#     mgr:
+#       ceph version 18.2.1 (7fe91d5d5842e04be3b4f514d6dd990c54b29c76) reef (stable): 1
+#     mon:
+#       ceph version 18.2.1 (7fe91d5d5842e04be3b4f514d6dd990c54b29c76) reef (stable): 1
+#     osd:
+#       ceph version 18.2.1 (7fe91d5d5842e04be3b4f514d6dd990c54b29c76) reef (stable): 1
+#     overall:
+#       ceph version 18.2.1 (7fe91d5d5842e04be3b4f514d6dd990c54b29c76) reef (stable): 3
+# conditions:
+# - lastHeartbeatTime: "2024-01-11T05:37:46Z"
+#   lastTransitionTime: "2024-01-11T05:37:46Z"
+#   message: Processing OSD 0 on node "minikube"
+#   reason: ClusterProgressing
+#   status: "True"
+#   type: Progressing
+# - lastHeartbeatTime: "2024-01-11T06:43:27Z"
+#   lastTransitionTime: "2024-01-11T05:38:27Z"
+#   message: Cluster created successfully
+#   reason: ClusterCreated
+#   status: "True"
+#   type: Ready
+# message: Cluster created successfully
+# observedGeneration: 2
+# phase: Ready
+# state: Created
+# storage:
+#   deviceClasses:
+#   - name: hdd
+#   osd:
+#     storeType:
+#       bluestore: 1
+# version:
+#   image: quay.io/ceph/ceph:v18
+#   version: 18.2.1-0
 ```
 
-## All Status
+## Status All
 
 ```bash
 kubectl rook-ceph rook status all
 
-# cephblockpoolradosnamespaces.ceph.rook.io:
-# cephblockpools.ceph.rook.io: {
-#   "observedGeneration": 2,
-#   "phase": "Failure"
-# }
-# {
-#   "phase": "Progressing"
-# }
-# cephbucketnotifications.ceph.rook.io:
-# cephbuckettopics.ceph.rook.io:
-# cephclients.ceph.rook.io:
-# cephclusters.ceph.rook.io: {
-#   "ceph": {
-#     "capacity": {},
-#     "fsid": "b74c18dd-6ee3-44fe-90b5-ed12feac46a4",
-#     "health": "HEALTH_OK",
-#     "lastChecked": "2022-09-14T08:57:00Z",
-#     "versions": {
-#       "mgr": {
-#         "ceph version 17.2.3 (dff484dfc9e19a9819f375586300b3b79d80034d) quincy (stable)": 1
-#       },
-#       "mon": {
-#         "ceph version 17.2.3 (dff484dfc9e19a9819f375586300b3b79d80034d) quincy (stable)": 3
-#       },
-#       "overall": {
-#         "ceph version 17.2.3 (dff484dfc9e19a9819f375586300b3b79d80034d) quincy (stable)": 4
-#       }
-#     }
-#   },
-#   "conditions": [
-#     {
-#       "lastHeartbeatTime": "2022-09-14T08:57:02Z",
-#       "lastTransitionTime": "2022-09-14T08:56:59Z",
-#       "message": "Cluster created successfully",
-#       "reason": "ClusterCreated",
-#       "status": "True",
-#       "type": "Ready"
-#     },
-#     {
-#       "lastHeartbeatTime": "2022-09-14T08:57:37Z",
-#       "lastTransitionTime": "2022-09-14T08:57:37Z",
-#       "message": "Configuring Ceph Mons",
-#       "reason": "ClusterProgressing",
-#       "status": "True",
-#       "type": "Progressing"
-#     }
-#   ],
-#   "message": "Configuring Ceph Mons",
-#   "observedGeneration": 2,
-#   "phase": "Progressing",
-#   "state": "Creating",
-#   "version": {
-#     "image": "quay.io/ceph/ceph:v17",
-#     "version": "17.2.3-0"
-#   }
-# }
-# cephfilesystemmirrors.ceph.rook.io:
-# cephfilesystems.ceph.rook.io:
-# cephfilesystemsubvolumegroups.ceph.rook.io:
-# cephnfses.ceph.rook.io:
-# cephobjectrealms.ceph.rook.io:
-# cephobjectstores.ceph.rook.io:
-# cephobjectstoreusers.ceph.rook.io:
-# cephobjectzonegroups.ceph.rook.io:
-# cephobjectzones.ceph.rook.io:
-# cephrbdmirrors.ceph.rook.io:
-# objectbucketclaims.objectbucket.io:
+# Info: cephclusters my-cluster
+# ceph:
+#   capacity:
+#     bytesAvailable: 20942770176
+#     bytesTotal: 20971520000
+#     bytesUsed: 28749824
+#     lastUpdated: "2024-01-11T06:44:28Z"
+#   details:
+#     POOL_APP_NOT_ENABLED:
+#       message: 1 pool(s) do not have an application enabled
+#       severity: HEALTH_WARN
+#   fsid: 5a8dc97a-1d21-4c0e-aac2-fdc924e18374
+#   health: HEALTH_WARN
+#   lastChanged: "2024-01-11T06:44:28Z"
+#   lastChecked: "2024-01-11T06:44:28Z"
+#   previousHealth: HEALTH_OK
+#   versions:
+#     mds:
+#       ceph version 18.2.1 (7fe91d5d5842e04be3b4f514d6dd990c54b29c76) reef (stable): 2
+#     mgr:
+#       ceph version 18.2.1 (7fe91d5d5842e04be3b4f514d6dd990c54b29c76) reef (stable): 1
+#     mon:
+#       ceph version 18.2.1 (7fe91d5d5842e04be3b4f514d6dd990c54b29c76) reef (stable): 1
+#     osd:
+#       ceph version 18.2.1 (7fe91d5d5842e04be3b4f514d6dd990c54b29c76) reef (stable): 1
+#     overall:
+#       ceph version 18.2.1 (7fe91d5d5842e04be3b4f514d6dd990c54b29c76) reef (stable): 5
+# conditions:
+# - lastHeartbeatTime: "2024-01-11T05:37:46Z"
+#   lastTransitionTime: "2024-01-11T05:37:46Z"
+#   message: Processing OSD 0 on node "minikube"
+#   reason: ClusterProgressing
+#   status: "True"
+#   type: Progressing
+# - lastHeartbeatTime: "2024-01-11T06:44:28Z"
+#   lastTransitionTime: "2024-01-11T05:38:27Z"
+#   message: Cluster created successfully
+#   reason: ClusterCreated
+#   status: "True"
+#   type: Ready
+# message: Cluster created successfully
+# observedGeneration: 2
+# phase: Ready
+# state: Created
+# storage:
+#   deviceClasses:
+#   - name: hdd
+#   osd:
+#     storeType:
+#       bluestore: 1
+# version:
+#   image: quay.io/ceph/ceph:v18
+#   version: 18.2.1-0
+
+# Info: resource cephblockpoolradosnamespaces was not found on the cluster
+# Info: cephblockpools builtin-mgr
+# observedGeneration: 2
+# phase: Ready
+
+# Info: resource cephbucketnotifications was not found on the cluster
+# Info: resource cephbuckettopics was not found on the cluster
+# Info: resource cephclients was not found on the cluster
+# Info: resource cephcosidrivers was not found on the cluster
+# Info: resource cephfilesystemmirrors was not found on the cluster
+# Info: cephfilesystems myfs
+# observedGeneration: 2
+# phase: Ready
+
+# Info: cephfilesystemsubvolumegroups myfs-csi
+# info:
+#   clusterID: e1026845ad66577abae1d16671b464c8
+# observedGeneration: 1
+# phase: Ready
+
+# Info: resource cephnfses was not found on the cluster
+# Info: resource cephobjectrealms was not found on the cluster
+# Info: resource cephobjectstores was not found on the cluster
+# Info: resource cephobjectstoreusers was not found on the cluster
+# Info: resource cephobjectzonegroups was not found on the cluster
+# Info: resource cephobjectzones was not found on the cluster
+# Info: resource cephrbdmirrors was not found on the cluster
 ```
 
 ## Status `<cr-name>`
@@ -170,49 +187,51 @@ kubectl rook-ceph rook status all
 ```bash
 kubectl rook-ceph rook status cephclusters
 
-# cephclusters.ceph.rook.io: {
-#   "ceph": {
-#     "capacity": {},
-#     "fsid": "b74c18dd-6ee3-44fe-90b5-ed12feac46a4",
-#     "health": "HEALTH_OK",
-#     "lastChecked": "2022-09-14T08:57:00Z",
-#     "versions": {
-#       "mgr": {
-#         "ceph version 17.2.3 (dff484dfc9e19a9819f375586300b3b79d80034d) quincy (stable)": 1
-#       },
-#       "mon": {
-#         "ceph version 17.2.3 (dff484dfc9e19a9819f375586300b3b79d80034d) quincy (stable)": 3
-#       },
-#       "overall": {
-#         "ceph version 17.2.3 (dff484dfc9e19a9819f375586300b3b79d80034d) quincy (stable)": 4
-#       }
-#     }
-#   },
-#   "conditions": [
-#     {
-#       "lastHeartbeatTime": "2022-09-14T08:57:02Z",
-#       "lastTransitionTime": "2022-09-14T08:56:59Z",
-#       "message": "Cluster created successfully",
-#       "reason": "ClusterCreated",
-#       "status": "True",
-#       "type": "Ready"
-#     },
-#     {
-#       "lastHeartbeatTime": "2022-09-14T08:57:37Z",
-#       "lastTransitionTime": "2022-09-14T08:57:37Z",
-#       "message": "Configuring Ceph Mons",
-#       "reason": "ClusterProgressing",
-#       "status": "True",
-#       "type": "Progressing"
-#     }
-#   ],
-#   "message": "Configuring Ceph Mons",
-#   "observedGeneration": 2,
-#   "phase": "Progressing",
-#   "state": "Creating",
-#   "version": {
-#     "image": "quay.io/ceph/ceph:v17",
-#     "version": "17.2.3-0"
-#   }
-# }
+# Info: cephclusters my-cluster
+# ceph:
+#   capacity:
+#     bytesAvailable: 20942778368
+#     bytesTotal: 20971520000
+#     bytesUsed: 28741632
+#     lastUpdated: "2024-01-11T06:43:27Z"
+#   fsid: 5a8dc97a-1d21-4c0e-aac2-fdc924e18374
+#   health: HEALTH_OK
+#   lastChanged: "2024-01-11T05:38:27Z"
+#   lastChecked: "2024-01-11T06:43:27Z"
+#   previousHealth: HEALTH_ERR
+#   versions:
+#     mgr:
+#       ceph version 18.2.1 (7fe91d5d5842e04be3b4f514d6dd990c54b29c76) reef (stable): 1
+#     mon:
+#       ceph version 18.2.1 (7fe91d5d5842e04be3b4f514d6dd990c54b29c76) reef (stable): 1
+#     osd:
+#       ceph version 18.2.1 (7fe91d5d5842e04be3b4f514d6dd990c54b29c76) reef (stable): 1
+#     overall:
+#       ceph version 18.2.1 (7fe91d5d5842e04be3b4f514d6dd990c54b29c76) reef (stable): 3
+# conditions:
+# - lastHeartbeatTime: "2024-01-11T05:37:46Z"
+#   lastTransitionTime: "2024-01-11T05:37:46Z"
+#   message: Processing OSD 0 on node "minikube"
+#   reason: ClusterProgressing
+#   status: "True"
+#   type: Progressing
+# - lastHeartbeatTime: "2024-01-11T06:43:27Z"
+#   lastTransitionTime: "2024-01-11T05:38:27Z"
+#   message: Cluster created successfully
+#   reason: ClusterCreated
+#   status: "True"
+#   type: Ready
+# message: Cluster created successfully
+# observedGeneration: 2
+# phase: Ready
+# state: Created
+# storage:
+#   deviceClasses:
+#   - name: hdd
+#   osd:
+#     storeType:
+#       bluestore: 1
+# version:
+#   image: quay.io/ceph/ceph:v18
+#   version: 18.2.1-0
 ```

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/rook/rook/pkg/apis v0.0.0-20231204200402-5287527732f7
 	github.com/spf13/cobra v1.8.0
 	github.com/stretchr/testify v1.8.4
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.29.1
 	k8s.io/apimachinery v0.29.1
 	k8s.io/client-go v0.29.1
@@ -77,7 +78,6 @@ require (
 	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/klog/v2 v2.110.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20231129212854-f0671cc7e66a // indirect
 	k8s.io/utils v0.0.0-20231127182322-b307cd553661 // indirect

--- a/pkg/crds/crds.go
+++ b/pkg/crds/crds.go
@@ -32,7 +32,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-var cephResources = []string{
+var CephResources = []string{
 	"cephclusters",
 	"cephblockpoolradosnamespaces",
 	"cephblockpools",
@@ -92,7 +92,7 @@ func DeleteCustomResources(ctx context.Context, clientsets k8sutil.ClientsetsInt
 }
 
 func deleteCustomResources(ctx context.Context, clientsets k8sutil.ClientsetsInterface, clusterNamespace string) error {
-	for _, resource := range cephResources {
+	for _, resource := range CephResources {
 		logging.Info("getting resource kind %s", resource)
 		items, err := clientsets.ListResourcesDynamically(ctx, CephRookIoGroup, CephRookResourcesVersion, resource, clusterNamespace)
 		if err != nil {


### PR DESCRIPTION
<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**
to get crd resources let's start using dynamic api
of kubernetes instead of using `kubectl` cli directly.
It make it platform independent wether it is `kubectl`
kubernetes or `oc` openshift.

Note: it changes how the command output used to be.

Signed-off-by: subhamkrai <srai@redhat.com>


**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] CI tests has been updated, if necessary.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
