### PR TITLE
Allow to delete subvolume with retain-snapshot feature

### DIFF
--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -79,9 +79,11 @@ jobs:
         run: |
           set -ex
           kubectl rook-ceph ceph fs subvolume create myfs test-subvol group-a
+          kubectl rook-ceph ceph fs subvolume create myfs test-subvol-1 group-a
           kubectl rook-ceph subvolume ls
           kubectl rook-ceph subvolume ls --stale
-          kubectl rook-ceph subvolume delete test-subvol myfs group-a
+          kubectl rook-ceph subvolume delete myfs test-subvol group-a
+          kubectl rook-ceph subvolume delete myfs test-subvol-1
 
       - name: Get mon endpoints
         run: |
@@ -234,10 +236,12 @@ jobs:
       - name: Subvolume command
         run: |
           set -ex
+          kubectl rook-ceph --operator-namespace test-operator -n test-cluster ceph fs subvolume create myfs test-subvol-1 group-a
           kubectl rook-ceph --operator-namespace test-operator -n test-cluster ceph fs subvolume create myfs test-subvol group-a
           kubectl rook-ceph --operator-namespace test-operator -n test-cluster subvolume ls
           kubectl rook-ceph --operator-namespace test-operator -n test-cluster subvolume ls --stale
-          kubectl rook-ceph --operator-namespace test-operator -n test-cluster subvolume delete test-subvol myfs group-a
+          kubectl rook-ceph --operator-namespace test-operator -n test-cluster subvolume delete myfs test-subvol group-a
+          kubectl rook-ceph --operator-namespace test-operator -n test-cluster subvolume delete myfs test-subvol-1 
 
       - name: Get mon endpoints
         run: |

--- a/cmd/commands/subvolume.go
+++ b/cmd/commands/subvolume.go
@@ -40,17 +40,19 @@ var listCmd = &cobra.Command{
 }
 
 var deleteCmd = &cobra.Command{
-	Use:                "delete",
-	Short:              "Deletes a stale subvolume.",
-	DisableFlagParsing: true,
-	Args:               cobra.ExactArgs(3),
-	Example:            "kubectl rook-ceph delete <subvolumes> <filesystem> <subvolumegroup>",
+	Use:     "delete",
+	Short:   "Deletes a stale subvolume.",
+	Args:    cobra.RangeArgs(2, 3),
+	Example: "kubectl rook-ceph delete <filesystem> <subvolume> [subvolumegroup]",
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := cmd.Context()
-		subList := args[0]
-		fs := args[1]
-		svg := args[2]
-		subvolume.Delete(ctx, clientSets, operatorNamespace, cephClusterNamespace, subList, fs, svg)
+		fs := args[0]
+		subvol := args[1]
+		svg := "csi"
+		if len(args) > 2 {
+			svg = args[2]
+		}
+		subvolume.Delete(ctx, clientSets, operatorNamespace, cephClusterNamespace, fs, subvol, svg)
 	},
 }
 

--- a/docs/subvolume.md
+++ b/docs/subvolume.md
@@ -9,12 +9,11 @@ and delete them without impacting other resources and attached volumes.
 The subvolume command will require the following sub commands:
 * `ls` : [ls](#ls) lists all the subvolumes
     * `--stale`: lists only stale subvolumes
-* `delete <subvolumes> <filesystem> <subvolumegroup>`:
-    [delete](#delete) stale subvolumes as per user's input.
-    It will list and delete only the stale subvolumes to prevent any loss of data.
-    * subvolumes: comma-separated list of subvolumes of same filesystem and subvolumegroup.
-    * filesystem: filesystem name to which the subvolumes belong. 
-    * subvolumegroup: subvolumegroup name to which the subvolumes belong.
+* `delete <filesystem> <subvolume> [subvolumegroup]`:
+    [delete](#delete) a stale subvolume.
+    * subvolume: subvolume name.
+    * filesystem: filesystem name to which the subvolume belongs.
+    * subvolumegroup: subvolumegroup name to which the subvolume belong(default is "csi")
 ## ls
 
 ```bash
@@ -23,8 +22,8 @@ kubectl rook-ceph subvolume ls
 # Filesystem  Subvolume  SubvolumeGroup  State
 # ocs-storagecluster-cephfilesystem csi-vol-427774b4-340b-11ed-8d66-0242ac110004 csi in-use
 # ocs-storagecluster-cephfilesystem csi-vol-427774b4-340b-11ed-8d66-0242ac110005 csi in-use
-# ocs-storagecluster-cephfilesystem csi-vol-427774b4-340b-11ed-8d66-0242ac110006 csi in-use
 # ocs-storagecluster-cephfilesystem csi-vol-427774b4-340b-11ed-8d66-0242ac110007 csi stale
+# ocs-storagecluster-cephfilesystem csi-vol-427774b4-340b-11ed-8d66-0242ac110007 csi stale-with-snapshot
 
 ```
 
@@ -33,23 +32,15 @@ kubectl rook-ceph subvolume ls --stale
 
 # Filesystem  Subvolume  SubvolumeGroup state
 # ocs-storagecluster-cephfilesystem csi-vol-427774b4-340b-11ed-8d66-0242ac110004 csi stale
-# ocs-storagecluster-cephfilesystem csi-vol-427774b4-340b-11ed-8d66-0242ac110005 csi stale
+# ocs-storagecluster-cephfilesystem csi-vol-427774b4-340b-11ed-8d66-0242ac110005 csi stale-with-snapshot
 
 ```
 
 ## delete
 
 ```bash
-kubectl rook-ceph subvolume delete csi-vol-427774b4-340b-11ed-8d66-0242ac110004 ocs-storagecluster csi
+kubectl rook-ceph subvolume delete ocs-storagecluster csi-vol-427774b4-340b-11ed-8d66-0242ac110004
 
-# Info: subvolume csi-vol-427774b4-340b-11ed-8d66-0242ac110004 deleted
-
-```
-
-```bash
-kubectl rook-ceph subvolume delete csi-vol-427774b4-340b-11ed-8d66-0242ac110004,csi-vol-427774b4-340b-11ed-8d66-0242ac110005 ocs-storagecluster csi
-
-# Info: subvolume csi-vol-427774b4-340b-11ed-8d66-0242ac110004 deleted
-# Info: subvolume csi-vol-427774b4-340b-11ed-8d66-0242ac110004 deleted
+# Info: subvolume "csi-vol-427774b4-340b-11ed-8d66-0242ac110004" deleted
 
 ```


### PR DESCRIPTION
This PR introduces the following enhancement to the stale subvolume cleanup process:
* Allow to delete the stale subvolumes that have snapshots with retain-snapshot feature
* Correct the order of arguments passed while deleting the subvolume
* Allow users to delete only one subvolume at a time.