### PR TITLE
mon: fetch good mon from socket command

### DIFF
--- a/docs/mons.md
+++ b/docs/mons.md
@@ -44,6 +44,7 @@ For example, here is the output in a test cluster up to the point of starting th
 
 ```
 $ kubectl rook-ceph mons restore-quorum c
+Info: mon c state is leader
 mon=b, endpoint=192.168.64.168:6789
 mon=c, endpoint=192.168.64.167:6789
 mon=a, endpoint=192.168.64.169:6789


### PR DESCRIPTION
let's validate the mon id passed by user based on which
quourm is restored. We don't want to restore quorum which is
not either 'leader' or 'peon'.

<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] CI tests has been updated, if necessary.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
