### PR TITLE
test: run rbd command with timeout after mon restore

### DIFF
--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -59,6 +59,20 @@ jobs:
           set -ex
           kubectl rook-ceph --context=$(kubectl config current-context) ceph status
 
+      - name: Rbd command
+        run: |
+          set -ex
+          SUCCEEDED=0
+          for ((i=0;i<30;i++)) ; do
+            timeout 10 kubectl rook-ceph rbd ls replicapool || continue
+            SUCCEEDED=1
+            break
+          done
+          if [ "${SUCCEEDED}" -ne 1 ]; then
+            echo "running rbd command timed out"
+            exit 1
+          fi
+
       - name: Mon restore
         run: |
           set -ex
@@ -69,11 +83,6 @@ jobs:
           tests/github-action-helper.sh wait_for_three_mons rook-ceph
           kubectl -n rook-ceph wait deployment rook-ceph-mon-d --for condition=Available=True --timeout=90s
           kubectl -n rook-ceph wait deployment rook-ceph-mon-e --for condition=Available=True --timeout=90s
-
-      - name: Rbd command
-        run: |
-          set -ex
-          kubectl rook-ceph rbd ls replicapool
 
       - name: Subvolume command
         run: |
@@ -215,6 +224,20 @@ jobs:
           set -ex
           kubectl rook-ceph --operator-namespace test-operator -n test-cluster --context=$(kubectl config current-context) ceph status
 
+      - name: Rbd command
+        run: |
+          set -ex
+          SUCCEEDED=0
+          for ((i=0;i<30;i++)) ; do
+            timeout 10 kubectl rook-ceph --operator-namespace test-operator -n test--cluster rbd ls replicapool || continue
+            SUCCEEDED=1
+            break
+          done
+          if [ "${SUCCEEDED}" -ne 1 ]; then
+            echo "running rbd command timed out"
+            exit 1
+          fi
+
       - name: Mon restore
         run: |
           set -ex
@@ -225,11 +248,6 @@ jobs:
           tests/github-action-helper.sh wait_for_three_mons test-cluster
           kubectl -n test-cluster wait deployment rook-ceph-mon-d --for condition=Available=True --timeout=90s
           kubectl -n test-cluster wait deployment rook-ceph-mon-e --for condition=Available=True --timeout=90s
-
-      - name: Rbd command
-        run: |
-          set -ex
-          kubectl rook-ceph --operator-namespace test-operator -n test-cluster rbd ls replicapool
 
       - name: Subvolume command
         run: |


### PR DESCRIPTION
**Description of your changes:**

Sometimes running rbd command hangs up just after mon restore. Then {default,custom}-namespace jobs stucks like this:
    
```
Run set -ex
+ set -ex
+ kubectl rook-ceph rbd ls replicapool
```
    
Run this command with timeout to avoid this test flakiness.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] CI tests has been updated, if necessary.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
