### PR TITLE
csi: return filesystem details

### DIFF
--- a/pkg/filesystem/subvolume.go
+++ b/pkg/filesystem/subvolume.go
@@ -123,7 +123,7 @@ func getFileSystem(ctx context.Context, clientsets *k8sutil.Clientsets, operator
 	if len(fsstruct) == 0 {
 		logging.Fatal(fmt.Errorf("no filesystem found"))
 	}
-	return []fsStruct{}, nil
+	return fsstruct, nil
 }
 
 // checkSnapshot checks if there are any snapshots in the subvolume


### PR DESCRIPTION
It seems the getfilesystem was always returning an empty struct. This commit returns the actaul
filesystem struct.

