### PR TITLE
ci: update runner go version to 1.21

### DIFF
--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -24,9 +24,7 @@ jobs:
           fetch-depth: 0
 
       - name: setup golang
-        uses: actions/setup-go@v5
-        with:
-          go-version: "1.20"
+        uses: ./.github/workflows/set-up-go
 
       - name: consider debugging
         uses: ./.github/workflows/tmate_debug
@@ -180,9 +178,7 @@ jobs:
           fetch-depth: 0
 
       - name: setup golang
-        uses: actions/setup-go@v5
-        with:
-          go-version: "1.20"
+        uses: ./.github/workflows/set-up-go
 
       - name: consider debugging
         uses: ./.github/workflows/tmate_debug
@@ -241,7 +237,7 @@ jobs:
           kubectl rook-ceph --operator-namespace test-operator -n test-cluster subvolume ls
           kubectl rook-ceph --operator-namespace test-operator -n test-cluster subvolume ls --stale
           kubectl rook-ceph --operator-namespace test-operator -n test-cluster subvolume delete myfs test-subvol group-a
-          kubectl rook-ceph --operator-namespace test-operator -n test-cluster subvolume delete myfs test-subvol-1 
+          kubectl rook-ceph --operator-namespace test-operator -n test-cluster subvolume delete myfs test-subvol-1
 
       - name: Get mon endpoints
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: setup golang
+        uses: ./.github/workflows/set-up-go
+
       - name: GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:

--- a/.github/workflows/set-up-go/action.yaml
+++ b/.github/workflows/set-up-go/action.yaml
@@ -1,0 +1,10 @@
+name: Set up Golang
+description:  Set up go for CI
+
+runs:
+  using: "composite"
+  steps:
+    - name: setup golang
+      uses: actions/setup-go@v5
+      with:
+        go-version: "1.21"


### PR DESCRIPTION
created a composite yaml for setting up go versio
that will be use for CI and releaser yaml. The releaser ci is failing https://github.com/rook/kubectl-rook-ceph/actions/runs/8003450560/job/21858788476 with error
```
  ⨯ release failed after 0s                  error=hook failed: shell: 'go mod tidy': exit status 1: go: go.mod file indicates go 1.21, but maximum version supported by tidy is 1.20
```
hopefull after this, releaser ci will be happy.

<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] CI tests has been updated, if necessary.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
