### PR TITLE
clean: increase the timeout to 15min

### DIFF
--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -153,7 +153,7 @@ jobs:
           set -ex
           kubectl rook-ceph destroy-cluster
           sleep 1
-          kubectl get deployments -n rook-ceph --no-headers| wc -l | (read n && [ $n -le 1 ] || { echo "the crs could not be deleted"; exit 1;})
+          kubectl get deployments -n rook-ceph --no-headers| wc -l | (read n && [ $n -le 1 ] || { echo "the crs could not be deleted"; kubectl get all -n rook-ceph; exit 1;})
 
       - name: collect common logs
         if: always()
@@ -309,7 +309,7 @@ jobs:
           set -ex
           kubectl rook-ceph --operator-namespace test-operator -n test-cluster destroy-cluster
           sleep 1
-          kubectl get deployments -n rook-ceph --no-headers| wc -l | (read n && [ $n -le 1 ] || { echo "the crs could not be deleted"; exit 1;})
+          kubectl get deployments -n test-cluster --no-headers| wc -l | (read n && [ $n -le 1 ] || { echo "the crs could not be deleted"; kubectl get all -n test-cluster; exit 1;})
 
       - name: collect common logs
         if: always()

--- a/pkg/crds/crds.go
+++ b/pkg/crds/crds.go
@@ -61,7 +61,7 @@ const (
 	CephResourceCephClusters = "cephclusters"
 	toolBoxDeployment        = "rook-ceph-tools"
 	timeOutCheckResources    = 5 * time.Second
-	maxExecutionTime         = 10 * time.Minute
+	maxExecutionTime         = 15 * time.Minute
 	maxDisplayedPods         = 10
 )
 


### PR DESCRIPTION


<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**
ci: fix namespace typo and add more log

fixing namespace typo in custom-ns test and also adding
more logs to print the resources which are not deleted after
running destroy-cluster command

clean: increase the timeout to 15min

ci can be slow sometimes so let's increase the
`destroy-cluster` timeout to 15min. As seen in
some ci clusters the resources are removed after some time.
![Screenshot from 2024-03-19 16-18-10](https://github.com/rook/kubectl-rook-ceph/assets/34444611/2f894900-02fa-44e4-8804-bf097d09d57c)


https://github.com/rook/kubectl-rook-ceph/actions/runs/8340959485/job/22826020306?pr=259
**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] CI tests has been updated, if necessary.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
