### PR TITLE
mon: remove unnecessary arg `public bind addr`

### DIFF
--- a/pkg/mons/restore_quorum.go
+++ b/pkg/mons/restore_quorum.go
@@ -192,7 +192,6 @@ func updateMonMap(ctx context.Context, clientsets *k8sutil.Clientsets, clusterNa
 		"--foreground",
 		fmt.Sprintf("--public-addr=%s", goodMonPublicIp),
 		fmt.Sprintf("--setuser-match-path=/var/lib/ceph/mon/ceph-%s/store.db", goodMon),
-		"--public-bind-addr=",
 	}
 
 	extractMonMap := []string{fmt.Sprintf("--extract-monmap=%s", monmapPath)}


### PR DESCRIPTION
since ceph reef, monMapArg `--public-bind-addr` is not required anymore.

<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #185 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] CI tests has been updated, if necessary.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
