### PR TITLE
core: add rados commands options

### DIFF
--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -56,6 +56,11 @@ jobs:
         run: |
           set -ex
           kubectl rook-ceph --context=$(kubectl config current-context) ceph status
+      
+      - name: Rados df using context
+        run: |
+          set -ex
+          kubectl rook-ceph --context=$(kubectl config current-context) rados df
 
       - name: Mon restore
         run: |
@@ -209,6 +214,11 @@ jobs:
         run: |
           set -ex
           kubectl rook-ceph --operator-namespace test-operator -n test-cluster ceph status
+
+      - name: Rados df
+        run: |
+          set -ex
+          kubectl rook-ceph --operator-namespace test-operator -n test-cluster rados df
 
       - name: Ceph status using context
         run: |

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ These are args currently supported:
 
 - `ceph <args>` : Run a Ceph CLI command. Supports any arguments the `ceph` command supports. See [Ceph docs](https://docs.ceph.com/en/pacific/start/intro/) for more.
 
+- `rados <args>` : Run a Rados CLI command. Supports any arguments the `rados` command supports. See [Rados docs](https://docs.ceph.com/en/latest/man/8/rados/) for more.
+
 - `rbd <args>` : Call a 'rbd' CLI command with arbitrary args
 
 - `mons` : Print mon endpoints
@@ -105,6 +107,7 @@ Visit docs below for complete details about each command and their flags uses.
 1. [Disaster Recovery](docs/dr-health.md)
 1. [Restore deleted CRs](docs/crd.md)
 1. [Destroy cluster](docs/destroy-cluster.md)
+2. [Running rados commands](docs/rados.md)
 
 ## Examples
 

--- a/cmd/commands/rados.go
+++ b/cmd/commands/rados.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2024 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+package command
+
+import (
+	"github.com/rook/kubectl-rook-ceph/pkg/exec"
+	"github.com/rook/kubectl-rook-ceph/pkg/logging"
+	"github.com/spf13/cobra"
+)
+
+// RadosCmd represents the rados command
+var RadosCmd = &cobra.Command{
+	Use:                "rados",
+	Short:              "call a 'rados' CLI command with arbitrary args",
+	DisableFlagParsing: true,
+	Args:               cobra.MinimumNArgs(1),
+	PreRun: func(cmd *cobra.Command, args []string) {
+		verifyOperatorPodIsRunning(cmd.Context(), clientSets)
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		logging.Info("running 'rados' command with args: %v", args)
+		_, err := exec.RunCommandInOperatorPod(cmd.Context(), clientSets, cmd.Use, args, operatorNamespace, cephClusterNamespace, false)
+		if err != nil {
+			logging.Fatal(err)
+		}
+	},
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -41,5 +41,6 @@ func addcommands() {
 		command.RestoreCmd,
 		command.DestroyClusterCmd,
 		command.SubvolumeCmd,
+		command.RadosCmd,
 	)
 }

--- a/docs/rados.md
+++ b/docs/rados.md
@@ -1,0 +1,50 @@
+# Rados
+
+This used to run any rados cli command with with arbitrary args.
+
+## Examples
+
+```bash
+kubectl rook-ceph rados df
+
+# POOL_NAME     USED  OBJECTS  CLONES  COPIES  MISSING_ON_PRIMARY  UNFOUND  DEGRADED  RD_OPS      RD  WR_OPS       WR  USED COMPR  UNDER COMPR
+# .mgr       452 KiB        2       0       2                   0        0         0      22  18 KiB      14  262 KiB         0 B          0 B
+
+# total_objects    2
+# total_used       27 MiB
+# total_avail      10 GiB
+# total_space      10 GiB
+```
+
+This also supports all the rados supported flags like `--format json-pretty`
+
+```bash
+kubectl rook-ceph rados df --format json-pretty
+
+# {
+#     "pools": [
+#         {
+#             "name": ".mgr",
+#             "id": 1,
+#             "size_bytes": 462848,
+#             "size_kb": 452,
+#             "num_objects": 2,
+#             "num_object_clones": 0,
+#             "num_object_copies": 2,
+#             "num_objects_missing_on_primary": 0,
+#             "num_objects_unfound": 0,
+#             "num_objects_degraded": 0,
+#             "read_ops": 22,
+#             "read_bytes": 18432,
+#             "write_ops": 14,
+#             "write_bytes": 268288,
+#             "compress_bytes_used": 0,
+#             "compress_under_bytes": 0
+#         }
+#     ],
+#     "total_objects": 2,
+#     "total_used": 27404,
+#     "total_avail": 10458356,
+#     "total_space": 10485760
+# }
+```


### PR DESCRIPTION
<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**
Add rados command option to kubectl-rook-ceph [Krew](https://github.com/kubernetes-sigs/krew) plugin.

**Which issue is resolved by this Pull Request:**
Resolves #268 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] CI tests has been updated, if necessary.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.


Procedure:
1.Create minikube on my local machine:
minikube start --disk-size=10g --extra-disks=1 --driver kvm2

2.Create Opertaor via conf files from rook repository https://github.com/rook/rook
$ cd deploy/examples/
$ kubectl create -f crds.yaml -f common.yaml -f operator.yaml
$ kubectl get pods -n rook-ceph
NAME                                 READY   STATUS    RESTARTS   AGE
rook-ceph-operator-757cdc49bb-qqffn   1/1     Running   0          89s

3.Create cluster-test:
$ cd deploy/examples/
$ kubectl create -f cluster-test.yaml 
configmap/rook-config-override created
cephcluster.ceph.rook.io/my-cluster created
cephblockpool.ceph.rook.io/builtin-mgr created

$ kubectl get cephcluster -A
NAMESPACE   NAME         DATADIRHOSTPATH   MONCOUNT   AGE   PHASE   MESSAGE                        HEALTH      EXTERNAL   FSID
rook-ceph   my-cluster   /var/lib/rook     1          54m   Ready   Cluster created successfully   HEALTH_OK              abdff5ae-c7cd-41dd-8cd1-661c1db844f8

4.Debug the code with visual studio /.vscode/launch.json
``` 
{
    "version": "0.2.0",
    "configurations": [
        {
            "name": "Launch",
            "type": "go",
            "request": "launch",
            "mode": "debug",
            "program": "${file}",
            "env": {},
            "args": ["rados", "status"]
        }
    ]
}
```
```
Starting: /home/oviner/go/bin/dlv dap --listen=127.0.0.1:37601 --log-dest=3 from /home/oviner/DEV_REPOS/kubectl-rook-ceph/cmd
DAP server listening at: 127.0.0.1:37601
Type 'dlv help' for list of commands.
Warning: rook version 'rook: v1.14.0-alpha.0.11.g79adfe74f' is running a pre-release version of Rook.

Info: running 'rados' command with args: [df]
POOL_NAME     USED  OBJECTS  CLONES  COPIES  MISSING_ON_PRIMARY  UNFOUND  DEGRADED  RD_OPS     RD  WR_OPS      WR  USED COMPR  UNDER COMPR
.mgr       452 KiB        2       0       2                   0        0         0       6  9 KiB       4  42 KiB         0 B          0 B

total_objects    2
total_used       27 MiB
total_avail      10 GiB
total_space      10 GiB
Process 179702 has exited with status 0
Detaching
```
