### PR TITLE
clean: Ensure cephcluster cleanup job runs

### DIFF
--- a/.github/workflows/go-test-config/action.yaml
+++ b/.github/workflows/go-test-config/action.yaml
@@ -197,4 +197,4 @@ runs:
         set -ex
         kubectl rook-ceph ${NS_OPT} destroy-cluster
         sleep 1
-        kubectl get deployments --no-headers| wc -l | (read n && [ $n -le 1 ] || { echo "the crs could not be deleted"; exit 1;})
+        kubectl get deployments --no-headers| wc -l | (read n && [ $n -le 3 ] || { echo "the crs could not be deleted"; exit 1;})

--- a/pkg/crds/crds.go
+++ b/pkg/crds/crds.go
@@ -167,6 +167,8 @@ func updatingFinalizers(ctx context.Context, clientsets k8sutil.ClientsetsInterf
 		if err != nil {
 			return err
 		}
+		logging.Info("Added cleanup policy to the cephcluster CR %q", resource)
+		return nil
 	}
 
 	jsonPatchData, _ := json.Marshal(DefaultResourceRemoveFinalizers)

--- a/pkg/k8sutil/k8sutil.go
+++ b/pkg/k8sutil/k8sutil.go
@@ -27,6 +27,7 @@ import (
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
@@ -112,8 +113,11 @@ func GetDeployment(ctx context.Context, k8sclientset kubernetes.Interface, clust
 
 func DeleteDeployment(ctx context.Context, k8sclientset kubernetes.Interface, clusterNamespace string, deployment string) {
 	logging.Info("removing deployment %s", deployment)
+	var gracePeriod int64
+	propagation := metav1.DeletePropagationForeground
+	options := &metav1.DeleteOptions{GracePeriodSeconds: &gracePeriod, PropagationPolicy: &propagation}
 
-	err := k8sclientset.AppsV1().Deployments(clusterNamespace).Delete(ctx, deployment, v1.DeleteOptions{})
+	err := k8sclientset.AppsV1().Deployments(clusterNamespace).Delete(ctx, deployment, *options)
 	if err != nil {
 		if k8sErrors.IsNotFound(err) {
 			logging.Info("the server could not find the requested deployment: %s", deployment)


### PR DESCRIPTION

<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**
The cleanup policy was not allowed to take effect during the cluster cleanup. The finalizer was immediately be removed instead of remaining until the operator has a chance to handle the cleanup policy and internally remove the finalizer. Now the cleanup policy is allowed to be applied and the cleanup job(s) will be started to cleanup the host path and disks from OSDs.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] CI tests has been updated, if necessary.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
