### PR TITLE
core: set pv name correctly on subvolume test

### DIFF
--- a/tests/github-action-helper.sh
+++ b/tests/github-action-helper.sh
@@ -100,8 +100,8 @@ create_stale_subvolume() {
   sed -i "s|storageClassName: rook-cephfs|storageClassName: rook-cephfs-retain|g" pvc.yaml
   kubectl create -f pvc.yaml
   kubectl get pvc cephfs-pvc-retain
-  : "${PVNAME:=$(kubectl get pvc cephfs-pvc-retain -o=jsonpath='{.spec.volumeName}')}"
   wait_for_pvc_to_be_bound_state_default
+  : "${PVNAME:=$(kubectl get pvc cephfs-pvc-retain -o=jsonpath='{.spec.volumeName}')}"
   kubectl get pvc cephfs-pvc-retain
   kubectl delete pvc cephfs-pvc-retain
   kubectl delete pv "$PVNAME"


### PR DESCRIPTION
**Description of your changes:**

PVC.spec.volumeName is empty if it's not bound to any PV. This problem can be avoided by getting the name
after verifying PVC to be bound.

ref. https://github.com/rook/kubectl-rook-ceph/actions/runs/8908445423/job/24464082185?pr=229#step:15:128
```
+ kubectl get pvc cephfs-pvc-retain
NAME                STATUS    VOLUME   CAPACITY   ACCESS MODES   STORAGECLASS         AGE
cephfs-pvc-retain   Pending                                      rook-cephfs-retain   0s
++ kubectl get pvc cephfs-pvc-retain '-o=jsonpath={.spec.volumeName}'
+ : ''
+ wait_for_pvc_to_be_bound_state_default
```

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
