### PR TITLE
core: Add status.phase=Running filter to WaitForPodToRun

### DIFF
--- a/pkg/k8sutil/k8sutil.go
+++ b/pkg/k8sutil/k8sutil.go
@@ -44,7 +44,7 @@ func RestartDeployment(ctx context.Context, k8sclientset kubernetes.Interface, n
 }
 
 func WaitForPodToRun(ctx context.Context, k8sclientset kubernetes.Interface, namespace, labelSelector string) (corev1.Pod, error) {
-	opts := v1.ListOptions{LabelSelector: labelSelector}
+	opts := v1.ListOptions{LabelSelector: labelSelector, FieldSelector: "status.phase=Running"}
 	for i := 0; i < 60; i++ {
 		pod, err := k8sclientset.CoreV1().Pods(namespace).List(ctx, opts)
 		if err != nil {


### PR DESCRIPTION
<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

To prevent pods in the `Completed` phase to show up in the list pulled by `WaitForPodToRun` (which resulted in an indefinitely hang), add a filter to only return pods in the `Running` phase.

**Issue resolved by this Pull Request:**
Resolves #304 

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
