### PR TITLE
csi: look for subvolumepath instead of subvolumename

### DIFF
--- a/pkg/filesystem/subvolume.go
+++ b/pkg/filesystem/subvolume.go
@@ -125,10 +125,29 @@ func getK8sRefSubvolume(ctx context.Context, clientsets *k8sutil.Clientsets) map
 	subvolumeNames := make(map[string]subVolumeInfo)
 	for _, pv := range pvList.Items {
 		if pv.Spec.CSI != nil {
-			subvolumeNames[pv.Spec.CSI.VolumeAttributes["subvolumeName"]] = subVolumeInfo{}
+			subvolumePath := pv.Spec.CSI.VolumeAttributes["subvolumePath"]
+			name, err := getSubvolumeNameFromPath(subvolumePath)
+			if err != nil {
+				logging.Error(err, "failed to get subvolume name")
+				continue
+			}
+			subvolumeNames[name] = subVolumeInfo{}
 		}
 	}
 	return subvolumeNames
+}
+
+// getSubvolumeNameFromPath get the subvolumename from the path.
+// subvolumepath: /volumes/csi/csi-vol-6a99b552-fdcc-441d-b1e6-a522a85a503d/5f4e4caa-f835-41ba-83c1-5bbd57f6aedf
+// subvolumename: csi-vol-6a99b552-fdcc-441d-b1e6-a522a85a503d
+func getSubvolumeNameFromPath(path string) (string, error) {
+	splitSubvol := strings.Split(path, "/")
+	if len(splitSubvol) < 4 {
+		return "", fmt.Errorf("failed to get name from subvolumepath: %s", path)
+	}
+	name := splitSubvol[3]
+
+	return name, nil
 }
 
 // runCommand checks for the presence of externalcluster and runs the command accordingly.

--- a/pkg/filesystem/subvolume_test.go
+++ b/pkg/filesystem/subvolume_test.go
@@ -16,7 +16,12 @@ limitations under the License.
 
 package subvolume
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 func TestGetOmapVal(t *testing.T) {
 
@@ -56,6 +61,43 @@ func TestGetOmapVal(t *testing.T) {
 			if val, subvolid := getOmapVal(tt.name); val != tt.val && subvolid != tt.subvolid {
 				t.Errorf("getOmapVal()= got val %v, want val %v,got subvolid %v want subvolid %v", val, tt.val, subvolid, tt.subvolid)
 			}
+		})
+	}
+}
+
+func TestGetSubvolumeNameFromPath(t *testing.T) {
+
+	tests := []struct {
+		path string
+		name string
+		err  error
+	}{
+		{
+			path: "/volumes/csi/csi-vol-6a99b552-fdcc-441d-b1e6-a522a85a503d/5f4e4caa-f835-41ba-83c1-5bbd57f6aedf",
+			name: "csi-vol-6a99b552-fdcc-441d-b1e6-a522a85a503d",
+		},
+		{
+			path: "",
+			err:  fmt.Errorf("failed to get name from subvolumepath: "),
+		},
+		{
+			path: "/volumes/csi-vol-6a99b552-fdcc-441d-b1e6-a522a85a503d/5f4e4caa-f835-41ba-83c1-5bbd57f6aedf",
+			name: "5f4e4caa-f835-41ba-83c1-5bbd57f6aedf",
+		},
+		{
+			path: "csi-vol-6a99b552-fdcc-441d-b1e6-a522a85a503d/5f4e4caa-f835-41ba-83c1-5bbd57f6aedf",
+			err:  fmt.Errorf(`failed to get name from subvolumepath: csi-vol-6a99b552-fdcc-441d-b1e6-a522a85a503d/5f4e4caa-f835-41ba-83c1-5bbd57f6aedf`),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			name, err := getSubvolumeNameFromPath(tt.path)
+			if err != nil {
+				assert.Error(t, err)
+				assert.Equal(t, tt.err.Error(), err.Error())
+				return
+			}
+			assert.Equal(t, name, tt.name)
 		})
 	}
 }


### PR DESCRIPTION
In case of ROX pvc, the subvolume name is different and is not listed in the backend as it is just a shallow volume and it links to the source path.
incase the source volume is delete the subvolme will be shown stale, but actually that is being used by the ROX pvc.
Soinstead getting the subvolumename to look for stale subvolumes, it is better to retrive the name from the subvolumepath.

