### PR TITLE
mons: restore-quorum should procced with probing

### DIFF
--- a/pkg/mons/restore_quorum.go
+++ b/pkg/mons/restore_quorum.go
@@ -327,7 +327,7 @@ func validateMonIsUp(ctx context.Context, clientsets *k8sutil.Clientsets, cluste
 
 	logging.Info("mon %q state is %q", monID, monStatusOut.State)
 
-	if monStatusOut.State == "leader" || monStatusOut.State == "peon" {
+	if monStatusOut.State == "leader" || monStatusOut.State == "peon" || monStatusOut.State == "probing" {
 		return nil
 	}
 


### PR DESCRIPTION
currently, mon restore-quorum fails if mon status is not in leader or peon but it should also include probing state as when majority of the mons down mons goes to probing state until it finds the other mons.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #323 


**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
