### PR TITLE
core: fix purge_osd command for multiple OSD IDs

### DIFF
--- a/docs/rook.md
+++ b/docs/rook.md
@@ -8,9 +8,9 @@ The `rook` command supports the following sub-commands:
 4. `status all`: [status all](#status-all) print the phase and conditions of all CRs
 5. `status <CR>`: [status  cr](#status-cr-name) print the phase and conditions of CRs of a specific type, such as 'cephobjectstore', 'cephfilesystem', etc
 
-## Purge an OSD
+## Purge OSDs
 
-Permanently remove an OSD from the cluster.
+Permanently remove OSD(s) from the cluster.
 
 !!! warning
     Data loss is possible when passing the --force flag if the PGs are not healthy on other OSDs.

--- a/pkg/rook/purge_osd.go
+++ b/pkg/rook/purge_osd.go
@@ -28,7 +28,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func PurgeOsd(ctx context.Context, clientsets *k8sutil.Clientsets, operatorNamespace, clusterNamespace, osdId, flag string) {
+func PurgeOsds(ctx context.Context, clientsets *k8sutil.Clientsets, operatorNamespace, clusterNamespace, osdIds, flag string) {
 	monCm, err := clientsets.Kube.CoreV1().ConfigMaps(clusterNamespace).Get(ctx, mons.MonConfigMap, v1.GetOptions{})
 	if err != nil {
 		logging.Fatal(fmt.Errorf("failed to get mon configmap %s %v", mons.MonConfigMap, err))
@@ -47,12 +47,12 @@ func PurgeOsd(ctx context.Context, clientsets *k8sutil.Clientsets, operatorNames
 	cmd := "/bin/sh"
 	args := []string{
 		"-c",
-		fmt.Sprintf("export ROOK_MON_ENDPOINTS=%s ROOK_CEPH_USERNAME=client.admin ROOK_CEPH_SECRET=%s ROOK_CONFIG_DIR=/var/lib/rook && rook ceph osd remove --osd-ids=%s --force-osd-removal=%s", monEndPoint, adminKey, osdId, flag),
+		fmt.Sprintf("export ROOK_MON_ENDPOINTS=%s ROOK_CEPH_USERNAME=client.admin ROOK_CEPH_SECRET=%s ROOK_CONFIG_DIR=/var/lib/rook && rook ceph osd remove --osd-ids=%s --force-osd-removal=%s", monEndPoint, adminKey, osdIds, flag),
 	}
 	logging.Info("Running purge osd command")
 
 	_, err = exec.RunCommandInOperatorPod(ctx, clientsets, cmd, args, operatorNamespace, clusterNamespace, false)
 	if err != nil {
-		logging.Fatal(err, "failed to remove osd %s", osdId)
+		logging.Fatal(err, "failed to remove osd %s", osdIds)
 	}
 }


### PR DESCRIPTION
Updating the command pre run to parse
the comma separated list of OSD IDs

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
