### PR TITLE
maintenance: remove hardcoded crd constants in restoreCrd

### DIFF
--- a/cmd/commands/restore.go
+++ b/cmd/commands/restore.go
@@ -17,6 +17,7 @@ limitations under the License.
 package command
 
 import (
+	"github.com/rook/kubectl-rook-ceph/pkg/crds"
 	"github.com/rook/kubectl-rook-ceph/pkg/restore"
 	"github.com/spf13/cobra"
 )
@@ -31,6 +32,6 @@ var RestoreCmd = &cobra.Command{
 		verifyOperatorPodIsRunning(cmd.Context(), clientSets)
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		restore.RestoreCrd(cmd.Context(), clientSets, operatorNamespace, cephClusterNamespace, args)
+		restore.RestoreCrd(cmd.Context(), clientSets, operatorNamespace, cephClusterNamespace, crds.CephRookIoGroup, crds.CephRookResourcesVersion, args)
 	},
 }

--- a/pkg/restore/crd.go
+++ b/pkg/restore/crd.go
@@ -32,7 +32,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-func RestoreCrd(ctx context.Context, k8sclientset *k8sutil.Clientsets, operatorNamespace, clusterNamespace string, args []string) {
+func RestoreCrd(ctx context.Context, k8sclientset *k8sutil.Clientsets, operatorNamespace, clusterNamespace,
+	groupName, versionResource string, args []string) {
 	crd := args[0]
 
 	var crName string
@@ -42,7 +43,7 @@ func RestoreCrd(ctx context.Context, k8sclientset *k8sutil.Clientsets, operatorN
 	}
 
 	logging.Info("Detecting which resources to restore for crd %q", crd)
-	crdList, err := k8sclientset.ListResourcesDynamically(ctx, crds.CephRookIoGroup, crds.CephRookResourcesVersion, crd, clusterNamespace)
+	crdList, err := k8sclientset.ListResourcesDynamically(ctx, groupName, versionResource, crd, clusterNamespace)
 	if err != nil {
 		logging.Fatal(fmt.Errorf("Failed to list resources for crd %v", err))
 	}


### PR DESCRIPTION
<!-- Thank you for contributing to Rook! -->
Refactored the RestoreCrd function to accept groupName and
versionResource as parameters instead of relying on the hardcoded
constants crds.CephRookIoGroup and crds.CephRookResourcesVersion.
This improves flexibility and allows the function to handle
different CRDs dynamically.

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
