### PR TITLE
csi: fix rbd listing failure by correctly filtering builtin block pools

### DIFF
--- a/pkg/rbd/rbd.go
+++ b/pkg/rbd/rbd.go
@@ -34,7 +34,7 @@ func fetchBlockPools(ctx context.Context, clientsets *k8sutil.Clientsets, cluste
 	}
 	blockPoolNames := make(map[string]poolData)
 	for _, blockPool := range blockPoolList.Items {
-		if blockPool.Name == "builtin-mgr" {
+		if strings.Contains(blockPool.Name, "builtin") {
 			continue
 		}
 		blockPoolNames[blockPool.Name] = poolData{


### PR DESCRIPTION
<!-- Thank you for contributing to Rook! -->
#356

Previously, the code only filtered out "builtin-mgr", but other builtin pools still caused rbd ls to fail. This fix updates the condition to exclude all pools containing "builtin", preventing errors when listing RBD images.

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
