### PR TITLE
core: remove unused Execute()

### DIFF
--- a/cmd/commands/root.go
+++ b/cmd/commands/root.go
@@ -57,12 +57,6 @@ var RootCmd = &cobra.Command{
 	},
 }
 
-// Execute adds all child commands to the root command and sets flags appropriately.
-// This is called by main.main(). It only needs to happen once to the rootCmd.
-func Execute() {
-	cobra.CheckErr(RootCmd.Execute())
-}
-
 func init() {
 	// Define your flags and configuration settings.
 	RootCmd.PersistentFlags().StringVar(&kubeConfig, "kubeconfig", "", "kubernetes config path")


### PR DESCRIPTION
The root command is executed from main() directly so Execute is unused. Its only effect seems to be confusing new contributor.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Documentation not needed.
- [x] Unit tests not needed.
- [x] Integration tests not needed.
