### PR TITLE
kubectl-ceph-rook: Fix IPv6 address handling in monitor endpoint parsing

### DIFF
--- a/pkg/mons/restore_quorum.go
+++ b/pkg/mons/restore_quorum.go
@@ -297,15 +297,19 @@ func getMonDetails(goodMon string, monEndpoints []string) ([]string, string, str
 		if !ok {
 			return []string{}, "", "", fmt.Errorf("failed to fetch mon endpoint")
 		} else if monName == goodMon {
-			goodMonPublicIp, goodMonPort, ok = strings.Cut(monEndpoint, ":")
-			if !ok {
-				return []string{}, "", "", fmt.Errorf("failed to get good mon endpoint and port")
+			host, port, err := ParseMonEndpoint(monEndpoint)
+			if err != nil {
+				return []string{}, "", "", err
 			}
+
+			goodMonPublicIp = host
+			goodMonPort = port
 		} else {
 			badMons = append(badMons, monName)
 		}
 		logging.Info("mon=%s, endpoints=%s\n", monName, monEndpoint)
 	}
+
 	return badMons, goodMonPublicIp, goodMonPort, nil
 }
 


### PR DESCRIPTION
## Description

This PR fixes an issue with the `kubectl-ceph-rook` plugin when working with Ceph clusters configured with IPv6 addresses. The current implementation of the `getMonDetails()` function fails to correctly parse IPv6 monitor endpoints, causing commands like `mons restore-quorum` to fail.

When running `kubectl rook-ceph mons restore-quorum` with IPv6 monitor addresses, the command fails with an error:

```
Info: mon=a, endpoints=[2a02:5501:31:c0a::3]:6789
Info: mon=b, endpoints=[2a02:5501:31:c0a::4]:6789
...
Info: Restoring mon quorum to mon b [2a02
...
parse error setting 'public_addr' to '[2a02'
too many arguments: [--setuser-match-path=/var/lib/ceph/mon/ceph-b/store.db]
Error: failed to run command. failed to run command. command terminated with exit code 1
%!(EXTRA string=failed to extract monmap)
```

The issue occurs because the `getMonDetails()` function uses a simple string split by the first colon to extract the IP address and port from monitor endpoints. This approach works for IPv4 addresses but fails for IPv6 addresses which contain multiple colons.

The fix enhances the `getMonDetails()` function to properly handle IPv6 addresses by checking if the endpoint contains more than one colon (indicating a possible IPv6 address) and using the last colon as the separator between the IP address and port for IPv6 addresses, while maintaining the existing behavior for IPv4 addresses.