### PR TITLE
mon: add support for restoring arbitrary CRs while the Rook resources are being deleted

### DIFF
--- a/cmd/commands/restore.go
+++ b/cmd/commands/restore.go
@@ -32,6 +32,7 @@ var RestoreCmd = &cobra.Command{
 		verifyOperatorPodIsRunning(cmd.Context(), clientSets)
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		restore.RestoreCrd(cmd.Context(), clientSets, operatorNamespace, cephClusterNamespace, crds.CephRookIoGroup, crds.CephRookResourcesVersion, args)
+		customResources := []restore.CustomResource{}
+		restore.RestoreCrd(cmd.Context(), clientSets, operatorNamespace, cephClusterNamespace, crds.CephRookIoGroup, crds.CephRookResourcesVersion, "rook-ceph-operator", customResources, args)
 	},
 }


### PR DESCRIPTION
<!-- Thank you for contributing to Rook! -->
This PR extends the `RestoreCrd` functionality to support restoring additional third-party CRs 

- Adds a `CustomResource` struct to pass a list of CRs to clean up ownerReferences
- Enhances `removeOwnerRefOfUID` to work with dynamically provided CRs
- Makes the operator name configurable to support tearing down and restarting a different operator (not just rook-ceph-operator)

This change improves flexibility in disaster recovery scenarios 
<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
