### PR TITLE
csi: handle missing subvolumePath in getk8sRefSubvolume

### DIFF
--- a/pkg/filesystem/subvolume.go
+++ b/pkg/filesystem/subvolume.go
@@ -137,30 +137,11 @@ func getK8sRefSubvolume(ctx context.Context, clientsets *k8sutil.Clientsets) map
 		if pv.Spec.CSI != nil {
 			driverName := pv.Spec.CSI.Driver
 			if strings.Contains(driverName, "cephfs.csi.ceph.com") {
-				subvolumePath := pv.Spec.CSI.VolumeAttributes["subvolumePath"]
-				name, err := getSubvolumeNameFromPath(subvolumePath)
-				if err != nil {
-					logging.Error(err, "failed to get subvolume name")
-					continue
-				}
-				subvolumeNames[name] = subVolumeInfo{}
+				subvolumeNames[pv.Spec.CSI.VolumeAttributes["subvolumeName"]] = subVolumeInfo{}
 			}
 		}
 	}
 	return subvolumeNames
-}
-
-// getSubvolumeNameFromPath get the subvolumename from the path.
-// subvolumepath: /volumes/csi/csi-vol-6a99b552-fdcc-441d-b1e6-a522a85a503d/5f4e4caa-f835-41ba-83c1-5bbd57f6aedf
-// subvolumename: csi-vol-6a99b552-fdcc-441d-b1e6-a522a85a503d
-func getSubvolumeNameFromPath(path string) (string, error) {
-	splitSubvol := strings.Split(path, "/")
-	if len(splitSubvol) < 4 {
-		return "", fmt.Errorf("failed to get name from subvolumepath: %s", path)
-	}
-	name := splitSubvol[3]
-
-	return name, nil
 }
 
 // getk8sRefSnapshotHandle returns the snapshothandle for k8s ref of the volume snapshots


### PR DESCRIPTION
pv parameter `subvolumePath` does not exist on some clusters, only subvolumeName is present. update `getk8sRefSubvolume` to use `subvolumeName` to avoid misidentifying volumes as stale


<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
