### PR TITLE
ci: Minor fixes in CI 

### DIFF
--- a/.github/workflows/go-test-config/action.yaml
+++ b/.github/workflows/go-test-config/action.yaml
@@ -178,7 +178,7 @@ runs:
         kubectl -n ${{ inputs.cluster-ns }} delete cephcluster my-cluster --timeout 3s --wait=false
 
         kubectl rook-ceph ${NS_OPT} restore-deleted cephclusters
-        tests/github-action-helper.sh wait_for_crd_to_be_ready ${{ inputs.cluster-ns }}
+        tests/github-action-helper.sh wait_for_ceph_cluster_to_be_ready ${{ inputs.cluster-ns }}
 
     - name: Restore CRD with CRName
       shell: bash --noprofile --norc -eo pipefail -x {0}
@@ -187,7 +187,7 @@ runs:
         kubectl -n ${{ inputs.cluster-ns }} delete cephcluster my-cluster --timeout 3s --wait=false
 
         kubectl rook-ceph ${NS_OPT} restore-deleted cephclusters my-cluster
-        tests/github-action-helper.sh wait_for_crd_to_be_ready ${{ inputs.cluster-ns }}
+        tests/github-action-helper.sh wait_for_ceph_cluster_to_be_ready ${{ inputs.cluster-ns }}
 
     - name: Show Cluster State
       shell: bash --noprofile --norc -eo pipefail -x {0}

--- a/tests/github-action-helper.sh
+++ b/tests/github-action-helper.sh
@@ -284,7 +284,7 @@ wait_for_deployment_to_be_running() {
   kubectl -n "$namespace" wait deployment "$deployment" --for condition=Available=True --timeout=90s
 }
 
-wait_for_crd_to_be_ready() {
+wait_for_ceph_cluster_to_be_ready() {
   export cluster_ns=$1
   timeout 300 bash <<-'EOF'
     set -x


### PR DESCRIPTION
The fixes include:

- Restarting the `rook-ceph-operator` pod during resource updates to avoid a race condition where a cached object version causes an error such as:
```
2025-10-23 06:42:59.103881 E | blockpool-rados-namespace-controller: failed to set ceph blockpool rados namespace "rook-ceph/namespace-b" status to "Ready". failed to update object "rook-ceph/namespace-b" status: Operation cannot be fulfilled on cephblockpoolradosnamespaces.ceph.rook.io "namespace-b": the object has been modified; please apply your changes to the latest version and try again
```

- Changing the function name from `wait_for_crd_to_be_ready` to `wait_for_cephcluster_to_be_ready` which reflects its purpose. 

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
