### PR TITLE
ci: update versions and optimize CI reliability

### DIFF
--- a/.github/workflows/cluster-setup/action.yaml
+++ b/.github/workflows/cluster-setup/action.yaml
@@ -17,7 +17,7 @@ runs:
     - name: Setup Minikube
       shell: bash --noprofile --norc -eo pipefail -x {0}
       run: |
-        tests/github-action-helper.sh install_minikube_with_none_driver v1.31.0
+        tests/github-action-helper.sh install_minikube_with_none_driver v1.31.3
 
     - name: print k8s cluster status
       shell: bash --noprofile --norc -eo pipefail -x {0}
@@ -29,7 +29,6 @@ runs:
       shell: bash --noprofile --norc -eo pipefail -x {0}
       run: tests/github-action-helper.sh use_local_disk
 
-
     - name: deploy rook cluster
       shell: bash --noprofile --norc -eo pipefail -x {0}
       if: inputs.op-ns == 'rook-ceph' || inputs.cluster-ns == 'rook-ceph'
@@ -38,4 +37,4 @@ runs:
     - name: deploy rook cluster in custom namespace
       shell: bash --noprofile --norc -eo pipefail -x {0}
       if: inputs.op-ns != 'rook-ceph' || inputs.cluster-ns != 'rook-ceph'
-      run: tests/github-action-helper.sh deploy_rook_in_custom_namespace ${{ inputs.op-ns }} ${{ inputs.cluster-ns }}
+      run: tests/github-action-helper.sh deploy_rook ${{ inputs.op-ns }} ${{ inputs.cluster-ns }}

--- a/.github/workflows/codespell.yaml
+++ b/.github/workflows/codespell.yaml
@@ -22,7 +22,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: codespell
-        uses: codespell-project/actions-codespell@master
+        uses: codespell-project/actions-codespell@v2.1
         with:
           skip: logo.svg,*.sum
           check_filenames: true

--- a/.github/workflows/collect-logs/action.yaml
+++ b/.github/workflows/collect-logs/action.yaml
@@ -5,12 +5,23 @@ inputs:
   name:
     description: Name to use for the workflow
     required: true
+  operator-namespace:
+    description: Operator namespace where rook operator is deployed
+    required: false
+    default: rook-ceph
+  cluster-namespace:
+    description: Cluster namespace where ceph cluster is deployed
+    required: false
+    default: rook-ceph
 
 runs:
   using: "composite"
   steps:
     - name: collect common logs
       shell: bash --noprofile --norc -eo pipefail -x {0}
+      env:
+        OPERATOR_NAMESPACE: ${{ inputs.operator-namespace }}
+        CLUSTER_NAMESPACE: ${{ inputs.cluster-namespace }}
       run: |
         tests/collect-logs.sh
 

--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -22,8 +22,8 @@ permissions:
 jobs:
   lint:
     permissions:
-      contents: read  # for actions/checkout to fetch code
-      pull-requests: read  # for wagoid/commitlint-github-action to get commits in PR
+      contents: read # for actions/checkout to fetch code
+      pull-requests: read # for wagoid/commitlint-github-action to get commits in PR
     runs-on: ubuntu-22.04
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: wagoid/commitlint-github-action@v6.2.1
+      - uses: wagoid/commitlint-github-action@v6
         with:
           configFile: "./.commitlintrc.json"
           helpURL: https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure

--- a/.github/workflows/go-test-config/action.yaml
+++ b/.github/workflows/go-test-config/action.yaml
@@ -178,7 +178,7 @@ runs:
         kubectl -n ${{ inputs.cluster-ns }} delete cephcluster my-cluster --timeout 3s --wait=false
 
         kubectl rook-ceph ${NS_OPT} restore-deleted cephclusters
-        tests/github-action-helper.sh wait_for_ceph_cluster_to_be_ready ${{ inputs.cluster-ns }}
+        tests/github-action-helper.sh wait_for_ceph_cluster_to_be_ready_state ${{ inputs.cluster-ns }}
 
     - name: Restore CRD with CRName
       shell: bash --noprofile --norc -eo pipefail -x {0}
@@ -187,7 +187,7 @@ runs:
         kubectl -n ${{ inputs.cluster-ns }} delete cephcluster my-cluster --timeout 3s --wait=false
 
         kubectl rook-ceph ${NS_OPT} restore-deleted cephclusters my-cluster
-        tests/github-action-helper.sh wait_for_ceph_cluster_to_be_ready ${{ inputs.cluster-ns }}
+        tests/github-action-helper.sh wait_for_ceph_cluster_to_be_ready_state ${{ inputs.cluster-ns }}
 
     - name: Show Cluster State
       shell: bash --noprofile --norc -eo pipefail -x {0}

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -23,11 +23,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: consider debugging
-        uses: ./.github/workflows/tmate_debug
-        with:
-          use-tmate: ${{ secrets.USE_TMATE }}
-
       - name: plugin test
         uses: ./.github/workflows/go-test-config
         with:
@@ -40,13 +35,14 @@ jobs:
         uses: ./.github/workflows/collect-logs
         with:
           name: go-test
+          operator-namespace: rook-ceph
+          cluster-namespace: rook-ceph
 
       - name: consider debugging
         if: failure()
         uses: mxschmitt/action-tmate@v3
         with:
           limit-access-to-actor: false
-
 
   custom-namespace:
     runs-on: ubuntu-22.04
@@ -57,12 +53,6 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
-
-      - name: consider debugging
-        if: failure()
-        uses: mxschmitt/action-tmate@v3
-        with:
-          use-tmate: ${{ secrets.USE_TMATE }}
 
       - name: plugin test
         uses: ./.github/workflows/go-test-config
@@ -76,6 +66,8 @@ jobs:
         uses: ./.github/workflows/collect-logs
         with:
           name: go-test-custom-namespace
+          operator-namespace: test-operator
+          cluster-namespace: test-cluster
 
       - name: consider debugging
         if: failure()

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
-          version: latest
+          version: ~> v2
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -27,4 +27,4 @@ jobs:
       # krew-release-bot is a bot that automates the update of plugin manifests in krew-index when a new version of your kubectl plugin is released.
       # https://github.com/rajatjindal/krew-release-bot
       - name: Update new version in krew-index
-        uses: rajatjindal/krew-release-bot@v0.0.47
+        uses: rajatjindal/krew-release-bot@v0.0.50

--- a/.github/workflows/tmate_debug/action.yml
+++ b/.github/workflows/tmate_debug/action.yml
@@ -22,3 +22,4 @@ runs:
       with:
         limit-access-to-actor: false
         detached: true
+        timeout-minutes: 60

--- a/tests/github-action-helper.sh
+++ b/tests/github-action-helper.sh
@@ -2,363 +2,468 @@
 
 set -xeEo pipefail
 
+# Source: https://github.com/rook/rook
+find_extra_block_dev() {
+    # shellcheck disable=SC2005 # redirect doesn't work with sudo, so use echo
+    echo "$(sudo lsblk)" >/dev/stderr # print lsblk output to stderr for debugging
+
+    # Find boot device
+    local boot_dev
+    boot_dev="$(sudo lsblk --noheading --list --output MOUNTPOINT,PKNAME | grep boot | awk '{print $2}')"
+    echo "  == find_extra_block_dev(): boot_dev='$boot_dev'" >/dev/stderr
+
+    # Find extra device (--nodeps ignores partitions)
+    local extra_dev
+    extra_dev="$(sudo lsblk --noheading --list --nodeps --output KNAME | grep -v loop | grep -v "$boot_dev" | head -1)"
+    echo "  == find_extra_block_dev(): extra_dev='$extra_dev'" >/dev/stderr
+
+    echo "$extra_dev"
+}
+
 #############
 # VARIABLES #
 #############
 : "${FUNCTION:=${1}}"
-
-# source https://github.com/rook/rook
-function find_extra_block_dev() {
-  # shellcheck disable=SC2005 # redirect doesn't work with sudo, so use echo
-  echo "$(sudo lsblk)" >/dev/stderr # print lsblk output to stderr for debugging in case of future errors
-  # relevant lsblk --pairs example: (MOUNTPOINT identifies boot partition)(PKNAME is Parent dev ID)
-  # NAME="sda15" SIZE="106M" TYPE="part" MOUNTPOINT="/boot/efi" PKNAME="sda"
-  # NAME="sdb"   SIZE="75G"  TYPE="disk" MOUNTPOINT=""          PKNAME=""
-  # NAME="sdb1"  SIZE="75G"  TYPE="part" MOUNTPOINT="/mnt"      PKNAME="sdb"
-  boot_dev="$(sudo lsblk --noheading --list --output MOUNTPOINT,PKNAME | grep boot | awk '{print $2}')"
-  echo "  == find_extra_block_dev(): boot_dev='$boot_dev'" >/dev/stderr # debug in case of future errors
-  # --nodeps ignores partitions
-  extra_dev="$(sudo lsblk --noheading --list --nodeps --output KNAME | grep -v loop | grep -v "$boot_dev" | head -1)"
-  echo "  == find_extra_block_dev(): extra_dev='$extra_dev'" >/dev/stderr # debug in case of future errors
-  echo "$extra_dev"                                                       # output of function
-}
-
 : "${BLOCK:=$(find_extra_block_dev)}"
 
-# source https://github.com/rook/rook
+# Default namespace values
+DEFAULT_OPERATOR_NS="rook-ceph"
+DEFAULT_CLUSTER_NS="rook-ceph"
+
+DEFAULT_TIMEOUT=600
+
+# Tool versions
+CRICTL_VERSION="v1.31.1"
+MINIKUBE_VERSION="v1.35.0"
+CNI_PLUGIN_VERSION="v1.6.0"
+EXTERNAL_SNAPSHOTTER_VERSION="8.2.0"
+
+# Download YAML files from URLs and modify them for custom namespaces
+# Arguments:
+#   $1: URL to download from
+#   $2: Output file name
+#   $3: Operator namespace (optional, defaults to rook-ceph)
+#   $4: Cluster namespace (optional, defaults to rook-ceph)
+download_and_modify_yaml() {
+    local url="$1"
+    local output_file="$2"
+    local operator_ns="${3:-$DEFAULT_OPERATOR_NS}"
+    local cluster_ns="${4:-$DEFAULT_CLUSTER_NS}"
+
+    echo "Downloading $output_file from $url"
+
+    if ! curl -fL "$url" -o "$output_file"; then
+        echo "Failed to download $output_file from $url" >&2
+        return 1
+    fi
+
+    # Apply namespace modifications if not using defaults
+    if [[ "$operator_ns" != "$DEFAULT_OPERATOR_NS" || "$cluster_ns" != "$DEFAULT_CLUSTER_NS" ]]; then
+        sed -i "s|rook-ceph # namespace:operator|${operator_ns} # namespace:operator|g" "$output_file"
+        sed -i "s|rook-ceph # namespace:cluster|${cluster_ns} # namespace:cluster|g" "$output_file"
+        # Handle other namespace references that might not have comments
+        sed -i "s|namespace: rook-ceph|namespace: ${operator_ns}|g" "$output_file"
+    fi
+}
+
+# Apply YAML with kubectl
+apply_yaml() {
+    local file="$1"
+    kubectl create -f "$file"
+}
+
+# Apply YAML from URL directly
+apply_yaml_from_url() {
+    local url="$1"
+    kubectl create -f "$url"
+}
+
+# Source: https://github.com/rook/rook
 use_local_disk() {
-  BLOCK_DATA_PART="/dev/${BLOCK}1"
-  sudo apt purge snapd -y
-  sudo dmsetup version || true
-  sudo swapoff --all --verbose
-  sudo umount /mnt
-  # search for the device since it keeps changing between sda and sdb
-  sudo wipefs --all --force "$BLOCK_DATA_PART"
+    local block_data_part="/dev/${BLOCK}1"
+
+    sudo apt purge snapd -y
+    sudo dmsetup version || true
+    sudo swapoff --all --verbose
+    sudo umount /mnt
+    sudo wipefs --all --force "$block_data_part"
 }
 
+# Deploy Rook-Ceph with support for both default and custom namespaces
+# This is the main deployment function that handles the entire process
+# Arguments:
+#   $1: Operator namespace (optional, defaults to rook-ceph)
+#   $2: Cluster namespace (optional, defaults to rook-ceph)
 deploy_rook() {
-  kubectl create -f https://raw.githubusercontent.com/rook/rook/master/deploy/examples/common.yaml
-  kubectl create -f https://raw.githubusercontent.com/rook/rook/master/deploy/examples/crds.yaml
-  kubectl create -f https://raw.githubusercontent.com/rook/rook/master/deploy/examples/operator.yaml
-  kubectl create -f https://raw.githubusercontent.com/rook/rook/master/deploy/examples/csi-operator.yaml
+    local operator_ns="${1:-$DEFAULT_OPERATOR_NS}"
+    local cluster_ns="${2:-$DEFAULT_CLUSTER_NS}"
 
-  wait_for_operator_pod_to_be_ready_state rook-ceph
-  curl https://raw.githubusercontent.com/rook/rook/master/deploy/examples/cluster-test.yaml -o cluster-test.yaml
-  sed -i "s|#deviceFilter:|deviceFilter: ${BLOCK/\/dev\//}|g" cluster-test.yaml
-  sed -i '0,/count: 1/ s/count: 1/count: 3/' cluster-test.yaml
-  kubectl create -f cluster-test.yaml
-  wait_for_pod_to_be_ready_state rook-ceph
-  kubectl create -f https://raw.githubusercontent.com/rook/rook/master/deploy/examples/toolbox.yaml
+    echo "Starting Rook-Ceph deployment"
+    echo "Operator namespace: $operator_ns"
+    echo "Cluster namespace: $cluster_ns"
 
-  deploy_csi_driver_default_ns
+    # Create custom namespaces if needed
+    if [[ "$operator_ns" != "$DEFAULT_OPERATOR_NS" ]]; then
+        echo "Creating operator namespace: $operator_ns"
+        kubectl create namespace "$operator_ns" || echo "Namespace $operator_ns already exists"
+    fi
+    if [[ "$cluster_ns" != "$DEFAULT_CLUSTER_NS" && "$cluster_ns" != "$operator_ns" ]]; then
+        echo "Creating cluster namespace: $cluster_ns"
+        kubectl create namespace "$cluster_ns" || echo "Namespace $cluster_ns already exists"
+    fi
+
+    echo "Deploying Rook common resources..."
+    download_and_modify_yaml "https://raw.githubusercontent.com/rook/rook/master/deploy/examples/common.yaml" "common.yaml" "$operator_ns" "$cluster_ns"
+    apply_yaml "common.yaml"
+
+    echo "Deploying Custom Resource Definitions (CRDs)..."
+    apply_yaml_from_url "https://raw.githubusercontent.com/rook/rook/master/deploy/examples/crds.yaml"
+
+    echo "Deploying Rook operator..."
+    download_and_modify_yaml "https://raw.githubusercontent.com/rook/rook/master/deploy/examples/operator.yaml" "operator.yaml" "$operator_ns" "$cluster_ns"
+    apply_yaml "operator.yaml"
+
+    echo "Deploying CSI operator..."
+    download_and_modify_yaml "https://raw.githubusercontent.com/rook/rook/master/deploy/examples/csi-operator.yaml" "csi-operator.yaml" "$operator_ns" "$cluster_ns"
+    apply_yaml "csi-operator.yaml"
+
+    # Wait for operator to be ready before proceeding
+    echo "Waiting for Rook operator to become ready..."
+    wait_for_operator_pod_to_be_ready_state "$operator_ns"
+
+    echo "Deploying Ceph cluster with device filter for $BLOCK..."
+    download_and_modify_yaml "https://raw.githubusercontent.com/rook/rook/master/deploy/examples/cluster-test.yaml" "cluster-test.yaml" "$operator_ns" "$cluster_ns"
+    sed -i "s|#deviceFilter:|deviceFilter: ${BLOCK/\/dev\//}|g" cluster-test.yaml
+    sed -i '0,/count: 1/ s/count: 1/count: 3/' cluster-test.yaml
+    apply_yaml "cluster-test.yaml"
+
+    echo "Waiting for Ceph cluster to become ready..."
+    wait_for_ceph_cluster_to_be_ready_state "$cluster_ns"
+
+    echo "Deploying Ceph toolbox for management..."
+    download_and_modify_yaml "https://raw.githubusercontent.com/rook/rook/master/deploy/examples/toolbox.yaml" "toolbox.yaml" "$operator_ns" "$cluster_ns"
+    apply_yaml "toolbox.yaml"
+
+    # Phase 3: Deploy storage drivers
+    echo "Deploying CSI drivers and storage classes..."
+    deploy_csi_drivers "$operator_ns" "$cluster_ns"
 }
 
-deploy_rook_in_custom_namespace() {
-  OPERATOR_NS=$1
-  CLUSTER_NS=$2
-  : "${OPERATOR_NS:=test-operator}"
-  : "${CLUSTER_NS:=test-cluster}"
+# Unified CSI driver deployment
+deploy_csi_drivers() {
+    local operator_ns="${1:-$DEFAULT_OPERATOR_NS}"
+    local cluster_ns="${2:-$DEFAULT_CLUSTER_NS}"
 
-  kubectl create namespace test-operator # creating namespace manually because rook common.yaml create one namespace and here we need 2
-  curl https://raw.githubusercontent.com/rook/rook/master/deploy/examples/common.yaml -o common.yaml
-  deploy_with_custom_ns "$OPERATOR_NS" "$CLUSTER_NS" common.yaml
-  kubectl create -f https://raw.githubusercontent.com/rook/rook/master/deploy/examples/crds.yaml
+    # Deploy filesystem
+    download_and_modify_yaml "https://raw.githubusercontent.com/rook/rook/master/deploy/examples/filesystem-test.yaml" "filesystem.yaml" "$operator_ns" "$cluster_ns"
+    apply_yaml "filesystem.yaml"
 
-  curl -f https://raw.githubusercontent.com/rook/rook/master/deploy/examples/operator.yaml -o operator.yaml
-  deploy_with_custom_ns "$OPERATOR_NS" "$CLUSTER_NS" operator.yaml
+    # Deploy subvolume group
+    download_and_modify_yaml "https://raw.githubusercontent.com/rook/rook/master/deploy/examples/subvolumegroup.yaml" "subvolumegroup.yaml" "$operator_ns" "$cluster_ns"
+    apply_yaml "subvolumegroup.yaml"
 
-  curl -f https://raw.githubusercontent.com/rook/rook/master/deploy/examples/csi-operator.yaml -o csi-operator.yaml
-  sed -i "s|namespace: rook-ceph|namespace: ${OPERATOR_NS}|g" csi-operator.yaml
-  kubectl create -f csi-operator.yaml
+    # Deploy RBD storage class
+    download_and_modify_yaml "https://raw.githubusercontent.com/rook/rook/master/deploy/examples/csi/rbd/storageclass-test.yaml" "storageclass-rbd.yaml" "$operator_ns" "$cluster_ns"
+    if [[ "$operator_ns" != "$DEFAULT_OPERATOR_NS" ]]; then
+        sed -i "s|provisioner: rook-ceph.rbd.csi.ceph.com|provisioner: ${operator_ns}.rbd.csi.ceph.com|g" storageclass-rbd.yaml
+    fi
+    apply_yaml "storageclass-rbd.yaml"
 
-  curl https://raw.githubusercontent.com/rook/rook/master/deploy/examples/cluster-test.yaml -o cluster-test.yaml
-  sed -i "s|#deviceFilter:|deviceFilter: ${BLOCK/\/dev\//}|g" cluster-test.yaml
-  sed -i '0,/count: 1/ s/count: 1/count: 3/' cluster-test.yaml
-  deploy_with_custom_ns "$OPERATOR_NS" "$CLUSTER_NS" cluster-test.yaml
-  wait_for_pod_to_be_ready_state $CLUSTER_NS
+    # Deploy CephFS storage class
+    download_and_modify_yaml "https://raw.githubusercontent.com/rook/rook/master/deploy/examples/csi/cephfs/storageclass.yaml" "storageclass-cephfs.yaml" "$operator_ns" "$cluster_ns"
+    if [[ "$operator_ns" != "$DEFAULT_OPERATOR_NS" ]]; then
+        sed -i "s|provisioner: rook-ceph.cephfs.csi.ceph.com|provisioner: ${operator_ns}.cephfs.csi.ceph.com|g" storageclass-cephfs.yaml
+    fi
+    apply_yaml "storageclass-cephfs.yaml"
 
-  curl -f https://raw.githubusercontent.com/rook/rook/master/deploy/examples/toolbox.yaml -o toolbox.yaml
-  deploy_with_custom_ns "$OPERATOR_NS" "$CLUSTER_NS" toolbox.yaml
+    # Deploy PVCs
+    apply_yaml_from_url "https://raw.githubusercontent.com/rook/rook/master/deploy/examples/csi/rbd/pvc.yaml"
+    apply_yaml_from_url "https://raw.githubusercontent.com/rook/rook/master/deploy/examples/csi/cephfs/pvc.yaml"
 
-  deploy_csi_driver_custom_ns "$OPERATOR_NS" "$CLUSTER_NS"
+    # Deploy RADOS namespace components
+    deploy_rados_namespace "$operator_ns" "$cluster_ns"
 }
 
+# Deploy RADOS namespace components
+deploy_rados_namespace() {
+    local operator_ns="${1:-$DEFAULT_OPERATOR_NS}"
+    local cluster_ns="${2:-$DEFAULT_CLUSTER_NS}"
+
+    # Create block pool for RADOS namespace
+    download_and_modify_yaml "https://raw.githubusercontent.com/rook/rook/master/deploy/examples/pool-test.yaml" "pool-rados-ns.yaml" "$operator_ns" "$cluster_ns"
+    sed -i "s|name: replicapool|name: blockpool-rados-ns|g" pool-rados-ns.yaml
+    apply_yaml "pool-rados-ns.yaml"
+    wait_for_cephblockpool_ready_state "$cluster_ns" "blockpool-rados-ns"
+
+    # Create first RADOS namespace (namespace-a)
+    download_and_modify_yaml "https://raw.githubusercontent.com/rook/rook/master/deploy/examples/radosnamespace.yaml" "cephblockpoolradosnamespace-namespace-a.yaml" "$operator_ns" "$cluster_ns"
+    sed -i "s|blockPoolName: replicapool|blockPoolName: blockpool-rados-ns|g" "cephblockpoolradosnamespace-namespace-a.yaml"
+    sed -i "s|name: namespace-a|name: namespace-a|g" "cephblockpoolradosnamespace-namespace-a.yaml"
+    apply_yaml "cephblockpoolradosnamespace-namespace-a.yaml"
+    sleep 10 # wait for the rns to be created
+
+    echo "Deleting rook operator pods to restart for namespace-a..."
+    kubectl delete pods -l app=rook-ceph-operator -n "$operator_ns" --force --grace-period=0 || true
+
+    echo "Waiting for Rook operator to be ready after restart..."
+    wait_for_operator_pod_to_be_ready_state "$operator_ns"
+    wait_for_cephblockpoolradosnamespace_ready_state "$cluster_ns" "namespace-a" "$DEFAULT_TIMEOUT" "$operator_ns"
+
+    # Create second RADOS namespace (namespace-b)
+    download_and_modify_yaml "https://raw.githubusercontent.com/rook/rook/master/deploy/examples/radosnamespace.yaml" "cephblockpoolradosnamespace-namespace-b.yaml" "$operator_ns" "$cluster_ns"
+    sed -i "s|blockPoolName: replicapool|blockPoolName: blockpool-rados-ns|g" "cephblockpoolradosnamespace-namespace-b.yaml"
+    sed -i "s|name: namespace-a|name: namespace-b|g" "cephblockpoolradosnamespace-namespace-b.yaml"
+    apply_yaml "cephblockpoolradosnamespace-namespace-b.yaml"
+    sleep 10 # wait for the rns to be created
+    echo "Deleting rook operator pods to restart for namespace-b..."
+    kubectl delete pods -l app=rook-ceph-operator -n "$operator_ns" --force --grace-period=0 || true
+
+    echo "Waiting for Rook operator to be ready after restart..."
+    wait_for_operator_pod_to_be_ready_state "$operator_ns"
+    wait_for_cephblockpoolradosnamespace_ready_state "$cluster_ns" "namespace-b" "$DEFAULT_TIMEOUT" "$operator_ns"
+
+
+    # Get cluster ID and create storage class
+    local cluster_id
+    cluster_id=$(kubectl -n "$cluster_ns" get cephblockpoolradosnamespace/namespace-a -o jsonpath='{.status.info.clusterID}')
+    echo "cluster_id=${cluster_id}"
+
+    download_and_modify_yaml "https://raw.githubusercontent.com/rook/rook/master/deploy/examples/csi/rbd/storageclass-test.yaml" "storageclass-rados-namespace.yaml" "$operator_ns" "$cluster_ns"
+    sed -i "s|clusterID: rook-ceph # namespace:cluster|clusterID: ${cluster_id}|g" storageclass-rados-namespace.yaml
+    sed -i "s|name: rook-ceph-block|name: rook-ceph-block-rados-namespace|g" storageclass-rados-namespace.yaml
+    sed -i "s|pool: replicapool|pool: blockpool-rados-ns|g" storageclass-rados-namespace.yaml
+    kubectl apply -f storageclass-rados-namespace.yaml
+
+    # Create PVC for RADOS namespace
+    if ! curl -fL "https://raw.githubusercontent.com/rook/rook/master/deploy/examples/csi/rbd/pvc.yaml" -o pvc-rados-namespace.yaml; then
+        echo "Failed to download PVC template for RADOS namespace" >&2
+        return 1
+    fi
+    sed -i "s|name: rbd-pvc|name: rbd-pvc-rados-namespace|g" pvc-rados-namespace.yaml
+    sed -i "s|storageClassName: rook-ceph-block|storageClassName: rook-ceph-block-rados-namespace|g" pvc-rados-namespace.yaml
+    apply_yaml "pvc-rados-namespace.yaml"
+}
+
+# Create storage class with retain policy
 create_sc_with_retain_policy() {
-  export OPERATOR_NS=$1
-  export CLUSTER_NS=$2
+    local operator_ns="${1:-$DEFAULT_OPERATOR_NS}"
+    local cluster_ns="${2:-$DEFAULT_CLUSTER_NS}"
 
-  curl https://raw.githubusercontent.com/rook/rook/master/deploy/examples/csi/cephfs/storageclass.yaml -o storageclass.yaml
-  sed -i "s|name: rook-cephfs|name: rook-cephfs-retain|g" storageclass.yaml
-  sed -i "s|reclaimPolicy: Delete|reclaimPolicy: Retain|g" storageclass.yaml
-  sed -i "s|provisioner: rook-ceph.cephfs.csi.ceph.com |provisioner: ${OPERATOR_NS}.cephfs.csi.ceph.com |g" storageclass.yaml
-  deploy_with_custom_ns $OPERATOR_NS $CLUSTER_NS storageclass.yaml
+    download_and_modify_yaml "https://raw.githubusercontent.com/rook/rook/master/deploy/examples/csi/cephfs/storageclass.yaml" "storageclass-retain.yaml" "$operator_ns" "$cluster_ns"
+    sed -i "s|name: rook-cephfs|name: rook-cephfs-retain|g" storageclass-retain.yaml
+    sed -i "s|reclaimPolicy: Delete|reclaimPolicy: Retain|g" storageclass-retain.yaml
+    if [[ "$operator_ns" != "$DEFAULT_OPERATOR_NS" ]]; then
+        sed -i "s|provisioner: rook-ceph.cephfs.csi.ceph.com|provisioner: ${operator_ns}.cephfs.csi.ceph.com|g" storageclass-retain.yaml
+    fi
+    apply_yaml "storageclass-retain.yaml"
 }
 
+# Create stale subvolume for testing
 create_stale_subvolume() {
-  curl https://raw.githubusercontent.com/rook/rook/master/deploy/examples/csi/cephfs/pvc.yaml -o pvc.yaml
-  sed -i "s|name: cephfs-pvc|name: cephfs-pvc-retain|g" pvc.yaml
-  sed -i "s|storageClassName: rook-cephfs|storageClassName: rook-cephfs-retain|g" pvc.yaml
-  kubectl create -f pvc.yaml
-  kubectl get pvc cephfs-pvc-retain
-  wait_for_pvc_to_be_bound_state
-  : "${PVNAME:=$(kubectl get pvc cephfs-pvc-retain -o=jsonpath='{.spec.volumeName}')}"
-  kubectl get pvc cephfs-pvc-retain
-  kubectl delete pvc cephfs-pvc-retain
-  kubectl delete pv "$PVNAME"
+    if ! curl -fL "https://raw.githubusercontent.com/rook/rook/master/deploy/examples/csi/cephfs/pvc.yaml" -o pvc-retain.yaml; then
+        echo "Failed to download PVC retain template" >&2
+        return 1
+    fi
+    sed -i "s|name: cephfs-pvc|name: cephfs-pvc-retain|g" pvc-retain.yaml
+    sed -i "s|storageClassName: rook-cephfs|storageClassName: rook-cephfs-retain|g" pvc-retain.yaml
+    apply_yaml "pvc-retain.yaml"
+
+    kubectl get pvc cephfs-pvc-retain
+    wait_for_pvc_to_be_bound_state "cephfs-pvc-retain" "default"
+
+    local pv_name
+    pv_name="$(kubectl get pvc cephfs-pvc-retain -o=jsonpath='{.spec.volumeName}')"
+    kubectl delete pvc cephfs-pvc-retain
+    kubectl delete pv "$pv_name"
 }
 
-deploy_with_custom_ns() {
-  export OPERATOR_NS=$1
-  export CLUSTER_NS=$2
-  export MANIFEST=$3
-  sed -i "s|rook-ceph # namespace:operator|${OPERATOR_NS} # namespace:operator|g" "${MANIFEST}"
-  sed -i "s|rook-ceph # namespace:cluster|${CLUSTER_NS} # namespace:cluster|g" "${MANIFEST}"
-  kubectl create -f "${MANIFEST}"
-}
 
-deploy_csi_driver_default_ns() {
-  kubectl create -f https://raw.githubusercontent.com/rook/rook/master/deploy/examples/filesystem-test.yaml
-  kubectl create -f https://raw.githubusercontent.com/rook/rook/master/deploy/examples/subvolumegroup.yaml
-  kubectl create -f https://raw.githubusercontent.com/rook/rook/master/deploy/examples/csi/rbd/storageclass-test.yaml
-  kubectl create -f https://raw.githubusercontent.com/rook/rook/master/deploy/examples/csi/rbd/pvc.yaml
-  kubectl create -f https://raw.githubusercontent.com/rook/rook/master/deploy/examples/csi/cephfs/storageclass.yaml
-  kubectl create -f https://raw.githubusercontent.com/rook/rook/master/deploy/examples/csi/cephfs/pvc.yaml
-  deploy_csi_driver_rados_namespace
-}
-
-deploy_csi_driver_rados_namespace() {
-  wait_for_cephblockpool_ready_state "rook-ceph" "replicapool" 60
-
-  curl https://raw.githubusercontent.com/rook/rook/refs/heads/master/deploy/examples/pool-test.yaml -o pool_rados_ns.yaml
-  sed -i "s|name: replicapool|name: blockpool-rados-ns |g" pool_rados_ns.yaml
-  kubectl create -f pool_rados_ns.yaml
-  wait_for_cephblockpool_ready_state "rook-ceph" "blockpool-rados-ns" 60
-
-  curl https://raw.githubusercontent.com/rook/rook/refs/heads/master/deploy/examples/radosnamespace.yaml -o cephblockpoolradosnamespace_a.yaml
-  sed -i "s|blockPoolName: replicapool|blockPoolName: blockpool-rados-ns |g" cephblockpoolradosnamespace_a.yaml
-  kubectl create -f cephblockpoolradosnamespace_a.yaml
-  wait_for_cephblockpoolradosnamespace_ready_state "rook-ceph" "namespace-a" 60
-
-  # Restart the rook-ceph-operator pod to ensure it picks up new resources
-  operator_pod=$(kubectl -n rook-ceph get pods -l app=rook-ceph-operator -o jsonpath='{.items[0].metadata.name}')
-  if [ -n "$operator_pod" ]; then
-    kubectl -n rook-ceph delete pod "$operator_pod"
-    echo "rook-ceph-operator pod $operator_pod deleted. Waiting for it to restart..."
-  else
-    echo "rook-ceph-operator pod not found, skipping restart."
-  fi
-  wait_for_operator_pod_to_be_ready_state rook-ceph
-
-  curl https://raw.githubusercontent.com/rook/rook/refs/heads/master/deploy/examples/radosnamespace.yaml -o cephblockpoolradosnamespace_b.yaml
-  sed -i "s|blockPoolName: replicapool|blockPoolName: blockpool-rados-ns |g" cephblockpoolradosnamespace_b.yaml
-  sed -i "s|name: namespace-a|name: namespace-b |g" cephblockpoolradosnamespace_b.yaml
-  kubectl create -f cephblockpoolradosnamespace_b.yaml
-  wait_for_cephblockpoolradosnamespace_ready_state "rook-ceph" "namespace-b" 60
-
-  cluster_id=$(kubectl -n rook-ceph get cephblockpoolradosnamespace/namespace-a -o jsonpath='{.status.info.clusterID}')
-  echo "cluster_id=${cluster_id}"
-
-  curl https://raw.githubusercontent.com/rook/rook/refs/heads/master/deploy/examples/csi/rbd/storageclass-test.yaml -o storageclass-rados-namespace.yaml
-  sed -i "s|clusterID: rook-ceph # namespace:cluster|clusterID: ${cluster_id} |g" storageclass-rados-namespace.yaml
-  sed -i "s|name: rook-ceph-block|name: rook-ceph-block-rados-namespace |g" storageclass-rados-namespace.yaml
-  sed -i "s|pool: replicapool|pool: blockpool-rados-ns |g" storageclass-rados-namespace.yaml
-  kubectl apply -f storageclass-rados-namespace.yaml
-
-  curl https://raw.githubusercontent.com/rook/rook/master/deploy/examples/csi/rbd/pvc.yaml -o pvc-rados-namespace.yaml
-  sed -i "s|name: rbd-pvc|name: rbd-pvc-rados-namespace |g" pvc-rados-namespace.yaml
-  sed -i "s|storageClassName: rook-ceph-block|storageClassName: rook-ceph-block-rados-namespace |g" pvc-rados-namespace.yaml
-  kubectl create -f pvc-rados-namespace.yaml
-}
-
-deploy_csi_driver_custom_ns() {
-  curl https://raw.githubusercontent.com/rook/rook/master/deploy/examples/csi/rbd/storageclass-test.yaml -o storageclass-rbd-test.yaml
-  sed -i "s|provisioner: rook-ceph.rbd.csi.ceph.com |provisioner: test-operator.rbd.csi.ceph.com |g" storageclass-rbd-test.yaml
-  deploy_with_custom_ns "$1" "$2" storageclass-rbd-test.yaml
-
-  curl https://raw.githubusercontent.com/rook/rook/master/deploy/examples/csi/cephfs/storageclass.yaml -o storageclass-cephfs-test.yaml
-  sed -i "s|provisioner: rook-ceph.cephfs.csi.ceph.com |provisioner: test-operator.cephfs.csi.ceph.com |g" storageclass-cephfs-test.yaml
-  deploy_with_custom_ns "$1" "$2" storageclass-cephfs-test.yaml
-  kubectl create -f https://raw.githubusercontent.com/rook/rook/master/deploy/examples/csi/rbd/pvc.yaml
-
-  curl -f https://raw.githubusercontent.com/rook/rook/master/deploy/examples/filesystem-test.yaml -o filesystem.yaml
-  deploy_with_custom_ns "$1" "$2" filesystem.yaml
-
-  curl -f https://raw.githubusercontent.com/rook/rook/master/deploy/examples/subvolumegroup.yaml -o subvolumegroup.yaml
-  deploy_with_custom_ns "$1" "$2" subvolumegroup.yaml
-  kubectl create -f https://raw.githubusercontent.com/rook/rook/master/deploy/examples/csi/cephfs/pvc.yaml
-}
+#################
+# WAIT FUNCTIONS
+#################
 
 wait_for_cephblockpoolradosnamespace_ready_state() {
-  local cluster_ns=$1
-  local namespace_name=$2
-  local timeout_duration=${3:-10} # Default timeout to 10 seconds if not provided
+    local cluster_ns="$1"
+    local namespace_name="$2"
+    local timeout_duration="${3:-$DEFAULT_TIMEOUT}"
 
-  export cluster_ns namespace_name # Export variables for use in the subshell
-
-  timeout "$timeout_duration" bash <<'EOF'
-    set -x
-    until [ "$(kubectl get CephBlockPoolRadosNamespace "$namespace_name" -n "$cluster_ns" -o jsonpath='{.status.phase}')" == "Ready" ]; do
-      echo "Waiting for CephBlockPoolRadosNamespace '$namespace_name' to be in 'Ready' phase..."
-      sleep 1
-      kubectl get CephBlockPoolRadosNamespace -A
-    done
-    echo "CephBlockPoolRadosNamespace $namespace_name is in Ready phase!"
-EOF
-
-  timeout_command_exit_code
+    echo "Waiting for CephBlockPoolRadosNamespace '$namespace_name' to be ready..."
+    if ! kubectl wait --for=jsonpath='{.status.phase}'=Ready CephBlockPoolRadosNamespace "$namespace_name" -n "$cluster_ns" --timeout="${timeout_duration}s"; then
+        echo "Timeout waiting for CephBlockPoolRadosNamespace $namespace_name" >&2
+        echo "Current RADOS namespaces:"
+        kubectl get CephBlockPoolRadosNamespace -A
+        exit 1
+    fi
+    echo "CephBlockPoolRadosNamespace $namespace_name is ready!"
 }
 
+# Wait for CephBlockPool to be ready
 wait_for_cephblockpool_ready_state() {
-  local cluster_ns=$1
-  local blockpool_name=$2
-  local timeout_duration=${3:-10} # Default timeout to 10 seconds if not provided
+    local cluster_ns="$1"
+    local blockpool_name="$2"
+    local timeout_duration="${3:-$DEFAULT_TIMEOUT}"
 
-  export cluster_ns blockpool_name # Export variables for use in the subshell
-
-  timeout "$timeout_duration" bash <<'EOF'
-    set -x
-    until [ "$(kubectl get CephBlockPool "$blockpool_name" -n "$cluster_ns" -o jsonpath='{.status.phase}')" == "Ready" ]; do
-      echo "Waiting for CephBlockPool $blockpool_name to be in Ready phase"
-      sleep 1
-      kubectl get CephBlockPool -A
-      kubectl describe CephBlockPool blockpool-rados-ns -n rook-ceph
-      kubectl get CephBlockPool blockpool-rados-ns -n rook-ceph -o yaml
-    done
+    echo "Waiting for CephBlockPool $blockpool_name to be in Ready phase"
+    if ! kubectl wait --for=jsonpath='{.status.phase}'=Ready CephBlockPool "$blockpool_name" -n "$cluster_ns" --timeout="${timeout_duration}s"; then
+        echo "Timeout waiting for CephBlockPool $blockpool_name" >&2
+        kubectl get CephBlockPool -A
+        kubectl describe CephBlockPool "$blockpool_name" -n "$cluster_ns"
+        exit 1
+    fi
     echo "CephBlockPool $blockpool_name is in Ready phase!"
-EOF
-
-  timeout_command_exit_code
 }
 
+# Wait for PVC to be bound
 wait_for_pvc_to_be_bound_state() {
-  timeout 100 bash <<-'EOF'
-    set -x
-    until [ $(kubectl get pvc cephfs-pvc-retain -o jsonpath='{.status.phase}') == "Bound" ]; do
-      echo "waiting for the pvc to be in bound state"
-      sleep 1
-    done
-EOF
-  timeout_command_exit_code
+    local pvc_name="${1:-cephfs-pvc-retain}"
+    local namespace="${2:-default}"
+
+    echo "Waiting for PVC $pvc_name to be in bound state"
+    kubectl wait --for=jsonpath='{.status.phase}'=Bound pvc "$pvc_name" -n "$namespace" --timeout=${DEFAULT_TIMEOUT}s
 }
 
-wait_for_pod_to_be_ready_state() {
-  export cluster_ns=$1
-  timeout 200 bash <<-'EOF'
-    set -x
-    until [ $(kubectl get pod -l app=rook-ceph-osd -n "${cluster_ns}" -o jsonpath='{.items[*].metadata.name}' -o custom-columns=READY:status.containerStatuses[*].ready | grep -c true) -eq 1 ]; do
-      echo "waiting for the pods to be in ready state"
-      sleep 1
-    done
-EOF
-  timeout_command_exit_code
+# Wait for ceph cluster to be ready
+wait_for_ceph_cluster_to_be_ready_state() {
+    local cluster_ns="$1"
+
+    echo "Waiting for CephCluster to be ready in namespace $cluster_ns"
+    if ! kubectl wait --for=condition=Ready cephcluster my-cluster -n "$cluster_ns" --timeout=${DEFAULT_TIMEOUT}s; then
+        echo "CephCluster failed to become ready, current status:"
+        kubectl get cephcluster -A
+        exit 1
+    fi
 }
 
+# Wait for operator pod to be ready
 wait_for_operator_pod_to_be_ready_state() {
-  export operator_ns=$1
-  timeout 100 bash <<-'EOF'
-    set -x
-    until [ $(kubectl get pod -l app=rook-ceph-operator -n "${operator_ns}" -o jsonpath='{.items[*].metadata.name}' -o custom-columns=READY:status.containerStatuses[*].ready | grep -c true) -eq 1 ]; do
-      echo "waiting for the operator to be in ready state"
-      sleep 1
-    done
-    echo "rook-ceph-operator pod is in ready state!"
-EOF
+    local operator_ns="$1"
+
+    echo "Waiting for operator pod to be ready in namespace $operator_ns"
+    kubectl wait --for=condition=Ready pod -l app=rook-ceph-operator -n "$operator_ns" --timeout=${DEFAULT_TIMEOUT}s
 }
 
 wait_for_three_mons() {
-  export namespace=$1
-  timeout 150 bash <<-'EOF'
+  local namespace=$1
+  timeout 600 bash <<EOF
     set -x
-    until [ $(kubectl -n $namespace get deploy -l app=rook-ceph-mon,mon_canary!=true | grep rook-ceph-mon | wc -l | awk '{print $1}' ) -eq 3 ]; do
-      echo "$(date) waiting for three mon deployments to exist"
+    until [ \$(kubectl -n $namespace get deploy -l app=rook-ceph-mon,mon_canary!=true | grep rook-ceph-mon | wc -l | awk '{print \$1}' ) -eq 3 ]; do
+      echo "\$(date) waiting for three mon deployments to exist"
       sleep 2
     done
 EOF
-  timeout_command_exit_code
 }
 
 wait_for_deployment_to_be_running() {
-  deployment=$1
-  namespace=$2
-  echo "Waiting for the pod from deployment \"$deployment\" to be running"
-  kubectl -n "$namespace" wait deployment "$deployment" --for condition=Available=True --timeout=90s
-}
+    local deployment="$1"
+    local namespace="$2"
 
-wait_for_ceph_cluster_to_be_ready() {
-  export cluster_ns=$1
-  timeout 300 bash <<-'EOF'
-    set -x
-    until [ $(kubectl -n "${cluster_ns}" get cephcluster my-cluster -o=jsonpath='{.status.phase}') == "Ready" ]; do
-      echo "Waiting for the CephCluster my-cluster to be in the Ready state..."
-      current_phase=$(kubectl -n "${cluster_ns}" get cephcluster my-cluster -o=jsonpath='{.status.phase}' 2>/dev/null || echo "not found")
-      echo "Current CephCluster phase: $current_phase"
-      kubectl get cephcluster -n "${cluster_ns}" -o wide 2>/dev/null || echo "CephCluster not accessible"
-      sleep 2
-    done
-    echo "CephCluster my-cluster is now in Ready state!"
-EOF
-}
+    if [[ -z "$deployment" || -z "$namespace" ]]; then
+        echo "Error: Both deployment and namespace parameters are required" >&2
+        return 1
+    fi
 
-timeout_command_exit_code() {
-  # timeout command return exit status 124 if command times out
-  if [ $? -eq 124 ]; then
-    echo "Timeout reached"
-    exit 1
-  fi
+    echo "Waiting for deployment '$deployment' to be available in namespace '$namespace'..."
+    kubectl -n "$namespace" wait deployment "$deployment" --for condition=Available=True --timeout=${DEFAULT_TIMEOUT}s
 }
 
 install_minikube_with_none_driver() {
-  CRICTL_VERSION="v1.31.1"
-  MINIKUBE_VERSION="v1.34.0"
+    local kubernetes_version="$1"
 
-  sudo apt update
-  sudo apt install -y conntrack socat
-  curl -LO https://storage.googleapis.com/minikube/releases/$MINIKUBE_VERSION/minikube_latest_amd64.deb
-  sudo dpkg -i minikube_latest_amd64.deb
-  rm -f minikube_latest_amd64.deb
+    if [[ -z "$kubernetes_version" ]]; then
+        echo "Error: Kubernetes version must be specified" >&2
+        echo "Usage: install_minikube_with_none_driver <k8s-version>" >&2
+        return 1
+    fi
 
-  curl -LO https://github.com/Mirantis/cri-dockerd/releases/download/v0.3.15/cri-dockerd_0.3.15.3-0.ubuntu-focal_amd64.deb
-  sudo dpkg -i cri-dockerd_0.3.15.3-0.ubuntu-focal_amd64.deb
-  rm -f cri-dockerd_0.3.15.3-0.ubuntu-focal_amd64.deb
+    echo "Installing minikube with Kubernetes $kubernetes_version"
 
-  wget https://github.com/kubernetes-sigs/cri-tools/releases/download/$CRICTL_VERSION/crictl-$CRICTL_VERSION-linux-amd64.tar.gz
-  sudo tar zxvf crictl-$CRICTL_VERSION-linux-amd64.tar.gz -C /usr/local/bin
-  rm -f crictl-$CRICTL_VERSION-linux-amd64.tar.gz
-  sudo sysctl fs.protected_regular=0
+    # Install system dependencies
+    echo "Installing system dependencies..."
+    sudo apt update
+    sudo apt install -y conntrack socat
 
-  CNI_PLUGIN_VERSION="v1.5.1"
-  CNI_PLUGIN_TAR="cni-plugins-linux-amd64-$CNI_PLUGIN_VERSION.tgz" # change arch if not on amd64
-  CNI_PLUGIN_INSTALL_DIR="/opt/cni/bin"
+    # Install minikube
+    echo "Installing minikube $MINIKUBE_VERSION..."
+    if ! curl -LO "https://storage.googleapis.com/minikube/releases/$MINIKUBE_VERSION/minikube_latest_amd64.deb"; then
+        echo "Failed to download minikube package" >&2
+        return 1
+    fi
+    sudo dpkg -i minikube_latest_amd64.deb
+    rm -f minikube_latest_amd64.deb
 
-  curl -LO "https://github.com/containernetworking/plugins/releases/download/$CNI_PLUGIN_VERSION/$CNI_PLUGIN_TAR"
-  sudo mkdir -p "$CNI_PLUGIN_INSTALL_DIR"
-  sudo tar -xf "$CNI_PLUGIN_TAR" -C "$CNI_PLUGIN_INSTALL_DIR"
-  rm "$CNI_PLUGIN_TAR"
+    # Install container runtime interface
+    echo "Installing cri-dockerd..."
+    if ! curl -LO "https://github.com/Mirantis/cri-dockerd/releases/download/v0.3.15/cri-dockerd_0.3.15.3-0.ubuntu-focal_amd64.deb"; then
+        echo "Failed to download cri-dockerd" >&2
+        return 1
+    fi
+    sudo dpkg -i "cri-dockerd_0.3.15.3-0.ubuntu-focal_amd64.deb"
+    rm -f "cri-dockerd_0.3.15.3-0.ubuntu-focal_amd64.deb"
 
-  export MINIKUBE_HOME=$HOME CHANGE_MINIKUBE_NONE_USER=true KUBECONFIG=$HOME/.kube/config
-  minikube start --kubernetes-version="$1" --driver=none --memory 6g --cpus=2 --addons ingress --cni=calico
+
+    # Install crictl (container runtime CLI)
+    echo "Installing crictl $CRICTL_VERSION..."
+    if ! curl -LO "https://github.com/kubernetes-sigs/cri-tools/releases/download/$CRICTL_VERSION/crictl-$CRICTL_VERSION-linux-amd64.tar.gz"; then
+        echo "Failed to download crictl" >&2
+        return 1
+    fi
+    sudo tar zxf "crictl-$CRICTL_VERSION-linux-amd64.tar.gz" -C /usr/local/bin
+    rm -f "crictl-$CRICTL_VERSION-linux-amd64.tar.gz"
+
+    # Configure system settings
+    echo "Configuring system settings..."
+    sudo sysctl fs.protected_regular=0
+
+    # Install CNI plugins
+    echo "Installing CNI plugins $CNI_PLUGIN_VERSION..."
+    local cni_plugin_tar="cni-plugins-linux-amd64-$CNI_PLUGIN_VERSION.tgz"
+    local cni_plugin_install_dir="/opt/cni/bin"
+
+    if ! curl -LO "https://github.com/containernetworking/plugins/releases/download/$CNI_PLUGIN_VERSION/$cni_plugin_tar"; then
+        echo "Failed to download CNI plugins" >&2
+        return 1
+    fi
+    sudo mkdir -p "$cni_plugin_install_dir"
+        sudo tar -xf "$cni_plugin_tar" -C "$cni_plugin_install_dir"
+        rm "$cni_plugin_tar"
+
+    # Start minikube cluster
+    echo "Starting minikube cluster..."
+    export MINIKUBE_HOME=$HOME CHANGE_MINIKUBE_NONE_USER=true KUBECONFIG=$HOME/.kube/config
+    minikube start \
+        --kubernetes-version="$kubernetes_version" \
+        --driver=none \
+        --memory 6g \
+        --cpus=2 \
+        --addons ingress \
+        --cni=calico
+
+    echo "Minikube installation completed successfully!"
 }
 
+# Install external snapshotter
 install_external_snapshotter() {
-  EXTERNAL_SNAPSHOTTER_VERSION=8.0.1
-  curl -L "https://github.com/kubernetes-csi/external-snapshotter/archive/refs/tags/v${EXTERNAL_SNAPSHOTTER_VERSION}.zip" -o external-snapshotter.zip
-  unzip -d /tmp external-snapshotter.zip
-  cd "/tmp/external-snapshotter-${EXTERNAL_SNAPSHOTTER_VERSION}"
+    echo "Installing external snapshotter version $EXTERNAL_SNAPSHOTTER_VERSION..."
 
-  kubectl kustomize client/config/crd | kubectl create -f -
-  kubectl -n kube-system kustomize deploy/kubernetes/snapshot-controller | kubectl create -f -
+    if ! curl -L "https://github.com/kubernetes-csi/external-snapshotter/archive/refs/tags/v${EXTERNAL_SNAPSHOTTER_VERSION}.zip" -o external-snapshotter.zip; then
+        echo "Failed to download external snapshotter" >&2
+        return 1
+    fi
+
+    unzip -d /tmp external-snapshotter.zip
+    cd "/tmp/external-snapshotter-${EXTERNAL_SNAPSHOTTER_VERSION}"
+
+    kubectl kustomize client/config/crd | kubectl create -f -
+    kubectl -n kube-system kustomize deploy/kubernetes/snapshot-controller | kubectl create -f -
 }
 
+# Wait for RBD PVC clone to be bound
 wait_for_rbd_pvc_clone_to_be_bound() {
-  kubectl create -f https://raw.githubusercontent.com/rook/rook/master/deploy/examples/csi/rbd/pvc-clone.yaml
+    echo "Creating RBD PVC clone..."
+    apply_yaml_from_url "https://raw.githubusercontent.com/rook/rook/master/deploy/examples/csi/rbd/pvc-clone.yaml"
 
-  timeout 100 bash <<-'EOF'
-    until [ $(kubectl get pvc rbd-pvc-clone -o jsonpath='{.status.phase}') == "Bound" ]; do
-      echo "waiting for the pvc clone to be in bound state"
-      sleep 1
-    done
-EOF
-  timeout_command_exit_code
+    echo "Waiting for PVC clone to be bound..."
+    kubectl wait --for=jsonpath='{.status.phase}'=Bound pvc rbd-pvc-clone --timeout=600s
 }
 
 ########
@@ -367,8 +472,11 @@ EOF
 
 FUNCTION="$1"
 shift # remove function arg now that we've recorded it
-# call the function with the remainder of the user-provided args
-if ! $FUNCTION "$@"; then
-  echo "Call to $FUNCTION was not successful" >&2
-  exit 1
+
+# Call the function with the remainder of the user-provided args
+if ! "$FUNCTION" "$@"; then
+    echo "Function '$FUNCTION' failed" >&2
+    exit 1
 fi
+
+echo "Function '$FUNCTION' completed successfully!"


### PR DESCRIPTION
This commit makes following changes

- Update minikube to v1.35.0, CNI plugins to v1.6.0, external-snapshotter to 8.2.0
- Update Kubernetes version from v1.31.0 to v1.31.3 in cluster setup
- Replace custom polling loops with native kubectl wait commands
- Increase timeouts for better CI stability (10s→60s for CRDs, 100s→300s for PVCs)
- Update GitHub Actions: shellcheck@v2.0.0, codespell@v2.1, commitlint@v6.2.2
- Pin GoReleaser version to ~> v2 for stability
- Fix deployment condition logic in cluster-setup action

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
