### PR TITLE
ci: use v0.0.47 krew-release-bot version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,4 +27,4 @@ jobs:
       # krew-release-bot is a bot that automates the update of plugin manifests in krew-index when a new version of your kubectl plugin is released.
       # https://github.com/rajatjindal/krew-release-bot
       - name: Update new version in krew-index
-        uses: rajatjindal/krew-release-bot@v0.0.50
+        uses: rajatjindal/krew-release-bot@v0.0.47


### PR DESCRIPTION
 ci: use v0.0.47 krew-release-bot version
 
version of krew-release-both was updated
to wrong version by mistake while doing
overall CI changes in this pr #410. So,
reverting it to the stable version
    
Signed-off-by: subhamkrai <srai@redhat.com>

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
