### PR TITLE
core: add consumer-context and rados-namespace flag for subvolume

### DIFF
--- a/.github/workflows/go-test-config/action.yaml
+++ b/.github/workflows/go-test-config/action.yaml
@@ -135,6 +135,20 @@ runs:
         kubectl rook-ceph ${NS_OPT} cephfs-snap ls --filesystem myfs --orphaned | grep csi-snap
         kubectl rook-ceph ${NS_OPT} cephfs-snap delete $subVol $snap --filesystem myfs
 
+    - name: Subvolume with consumer-context
+      shell: bash --noprofile --norc -eo pipefail -x {0}
+      run: |
+        set -ex
+        tests/github-action-helper.sh create_consumer_context consumer-ctx
+        kubectl rook-ceph ${NS_OPT} subvolume ls --consumer-context=consumer-ctx
+        kubectl rook-ceph ${NS_OPT} subvolume ls --stale --consumer-context=consumer-ctx
+        # verify invalid context fails
+        if kubectl rook-ceph ${NS_OPT} subvolume ls --consumer-context=nonexistent-ctx 2>/dev/null; then
+          echo "ERROR: expected failure with invalid --consumer-context"
+          exit 1
+        fi
+        echo "Invalid consumer-context correctly rejected"
+
     - name: Get rbd list
       shell: bash --noprofile --norc -eo pipefail -x {0}
       run: |

--- a/.github/workflows/go-test-config/action.yaml
+++ b/.github/workflows/go-test-config/action.yaml
@@ -114,7 +114,7 @@ runs:
         kubectl rook-ceph ${NS_OPT} subvolume delete myfs test-subvol group-a
         tests/github-action-helper.sh create_sc_with_retain_policy ${{ inputs.op-ns }} ${{ inputs.cluster-ns }}
         tests/github-action-helper.sh create_stale_subvolume
-        subVol=$(kubectl rook-ceph ${NS_OPT} subvolume ls --stale | awk '{print $2}' | grep csi-vol)
+        subVol=$(kubectl rook-ceph ${NS_OPT} subvolume ls --stale | awk '{print $2}' | grep csi-vol | head -1)
         kubectl rook_ceph ${NS_OPT} subvolume delete myfs $subVol
 
     - name: CephFS Snapshot command
@@ -148,6 +148,33 @@ runs:
           exit 1
         fi
         echo "Invalid consumer-context correctly rejected"
+
+    - name: Subvolume delete with custom SVG and explicit rados-namespace
+      shell: bash --noprofile --norc -eo pipefail -x {0}
+      env:
+        OP_NS: ${{ inputs.op-ns }}
+        CLUSTER_NS: ${{ inputs.cluster-ns }}
+      run: |
+        set -ex
+        SVG=test-svg
+        # Creates SVG CR, matching Retain StorageClass with
+        # subvolumeGroup=$SVG, PVC, then deletes PVC/PV so the
+        # subvolume is stale.  CephFS CSI always stores OMAP in
+        # the "csi" rados namespace (cluster-level ConfigMap default).
+        tests/github-action-helper.sh create_stale_subvolume_in_svg \
+          "$SVG" "$OP_NS" "$CLUSTER_NS"
+        subVol=$(kubectl rook-ceph ${NS_OPT} subvolume ls --stale \
+          --svg "$SVG" | awk '{print $2}' | grep csi-vol | head -1)
+        # Pass --rados-namespace=csi explicitly to verify the flag
+        # is wired through the delete path.
+        kubectl rook-ceph ${NS_OPT} subvolume delete myfs \
+          "$subVol" "$SVG" --rados-namespace=csi
+        # verify subvolume is gone
+        remaining=$(kubectl rook-ceph ${NS_OPT} subvolume ls --stale \
+          --svg "$SVG" \
+          | awk '{print $2}' | grep -c "^${subVol}$" || true)
+        [ "$remaining" -eq 0 ] || \
+          { echo "ERROR: subvolume $subVol still listed after delete"; exit 1; }
 
     - name: Get rbd list
       shell: bash --noprofile --norc -eo pipefail -x {0}

--- a/cmd/commands/cephfs_snapshots.go
+++ b/cmd/commands/cephfs_snapshots.go
@@ -53,7 +53,8 @@ var cephFSSnapshotDeleteCmd = &cobra.Command{
 		snap := args[1]
 		fs, _ := cmd.Flags().GetString("filesystem")
 		svg, _ := cmd.Flags().GetString("svg")
-		filesystem.SnapshotDelete(cmd.Context(), clientSets, operatorNamespace, cephClusterNamespace, fs, subvol, snap, svg)
+		radosNamespace, _ := cmd.Flags().GetString("rados-namespace")
+		filesystem.SnapshotDelete(cmd.Context(), clientSets, operatorNamespace, cephClusterNamespace, fs, subvol, snap, svg, radosNamespace)
 	},
 }
 
@@ -62,5 +63,6 @@ func init() {
 	cephFSSnapshotListCmd.PersistentFlags().Bool("orphaned", false, "List only orphaned snapshots")
 	CephFSSnapshotCmd.PersistentFlags().String("svg", "csi", "The name of the subvolume group")
 	CephFSSnapshotCmd.PersistentFlags().String("filesystem", "myfs", "The name of the CephFS filesystem")
+	CephFSSnapshotCmd.PersistentFlags().String("rados-namespace", "csi", "The rados namespace for omap operations")
 	CephFSSnapshotCmd.AddCommand(cephFSSnapshotDeleteCmd)
 }

--- a/cmd/commands/root.go
+++ b/cmd/commands/root.go
@@ -40,6 +40,7 @@ import (
 var (
 	operatorNamespace    string
 	cephClusterNamespace string
+	consumerContext      string
 	clientSets           *k8sutil.Clientsets
 	clientConfig         clientcmd.ClientConfig
 )
@@ -70,6 +71,7 @@ func init() {
 	// Initialize client configuration with all standard kubectl flags first
 	clientConfig = defaultClientConfig(RootCmd.PersistentFlags())
 	RootCmd.PersistentFlags().StringVar(&operatorNamespace, "operator-namespace", "", "Kubernetes namespace where rook operator is running")
+	RootCmd.PersistentFlags().StringVar(&consumerContext, "consumer-context", "", "Kubernetes context for PV and VolumeSnapshotContent lookups (defaults to the current context)")
 
 	// Set default ceph cluster namespace
 	cephClusterNamespace = "rook-ceph"
@@ -154,6 +156,24 @@ func getClientsets(ctx context.Context) *k8sutil.Clientsets {
 	clientsets.Dynamic, err = dynamic.NewForConfig(clientsets.KubeConfig)
 	if err != nil {
 		logging.Fatal(err)
+	}
+
+	if consumerContext == "" {
+		clientsets.ConsumerConfig = clientsets.KubeConfig
+		clientsets.ConsumerKube = clientsets.Kube
+	} else {
+		consumerLoadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+		consumerLoadingRules.ExplicitPath = clientConfig.ConfigAccess().GetExplicitFile()
+		consumerOverrides := &clientcmd.ConfigOverrides{CurrentContext: consumerContext}
+		consumerClientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(consumerLoadingRules, consumerOverrides)
+		clientsets.ConsumerConfig, err = consumerClientConfig.ClientConfig()
+		if err != nil {
+			logging.Fatal(fmt.Errorf("failed to build config for --consumer-context %q: %v", consumerContext, err))
+		}
+		clientsets.ConsumerKube, err = k8s.NewForConfig(clientsets.ConsumerConfig)
+		if err != nil {
+			logging.Fatal(fmt.Errorf("failed to build kube client for --consumer-context %q: %v", consumerContext, err))
+		}
 	}
 
 	return clientsets

--- a/cmd/commands/root_test.go
+++ b/cmd/commands/root_test.go
@@ -43,3 +43,13 @@ go: go1.19.10s`
 		})
 	}
 }
+
+func TestConsumerContextFlag(t *testing.T) {
+	flag := RootCmd.PersistentFlags().Lookup("consumer-context")
+	if flag == nil {
+		t.Fatal("expected --consumer-context flag to be registered")
+	}
+	if flag.DefValue != "" {
+		t.Errorf("expected default value \"\", got %q", flag.DefValue)
+	}
+}

--- a/cmd/commands/subvolume.go
+++ b/cmd/commands/subvolume.go
@@ -37,7 +37,8 @@ var listCmd = &cobra.Command{
 		ctx := cmd.Context()
 		staleSubvol, _ := cmd.Flags().GetBool("stale")
 		svgName, _ := cmd.Flags().GetString("svg")
-		subvolume.List(ctx, clientSets, operatorNamespace, cephClusterNamespace, svgName, staleSubvol)
+		radosNamespace, _ := cmd.Flags().GetString("rados-namespace")
+		subvolume.List(ctx, clientSets, operatorNamespace, cephClusterNamespace, svgName, staleSubvol, radosNamespace)
 	},
 }
 
@@ -54,7 +55,8 @@ var deleteCmd = &cobra.Command{
 		if len(args) > 2 {
 			svg = args[2]
 		}
-		subvolume.Delete(ctx, clientSets, operatorNamespace, cephClusterNamespace, fs, subvol, svg)
+		radosNamespace, _ := cmd.Flags().GetString("rados-namespace")
+		subvolume.Delete(ctx, clientSets, operatorNamespace, cephClusterNamespace, fs, subvol, svg, radosNamespace)
 	},
 }
 
@@ -62,5 +64,6 @@ func init() {
 	SubvolumeCmd.AddCommand(listCmd)
 	SubvolumeCmd.PersistentFlags().Bool("stale", false, "List only stale subvolumes")
 	SubvolumeCmd.PersistentFlags().String("svg", "csi", "The name of the subvolume group")
+	SubvolumeCmd.PersistentFlags().String("rados-namespace", "csi", "The rados namespace for omap operations")
 	SubvolumeCmd.AddCommand(deleteCmd)
 }

--- a/docs/cephfs-snapshots.md
+++ b/docs/cephfs-snapshots.md
@@ -13,6 +13,7 @@ The cephfs-snap command will require the following sub commands:
   * `--orphaned`: lists only orphaned snapshots
   * `--svg <subvolumegroupname>`: lists snapshots in a particular subvolume group (default is "csi")
   * `--filesystem <filesystemname>`: lists snapshots in a particular filesystem (default is "myfs")
+  * `--consumer-context <context>`: Kubernetes context for PV and VolumeSnapshotContent lookups (default is the current context)
 * `delete <filesystem> <subvolume> <snapshot>`:
     [delete](#delete) an orphaned snapshot.
   * filesystem: filesystem name to which the snapshot belongs.
@@ -20,6 +21,7 @@ The cephfs-snap command will require the following sub commands:
   * snapshot: snapshot name.
   * `--svg <subvolumegroupname>`: subvolume group name (default is "csi")
   * `--filesystem <filesystemname>`: lists snapshots in a particular filesystem (default is "myfs")
+  * `--consumer-context <context>`: Kubernetes context for PV and VolumeSnapshotContent lookups (default is the current context)
 
 ## ls
 
@@ -46,6 +48,25 @@ Filesystem                         Subvolume                                    
 myfs                               csi-vol-aa0099b5-f7a0-49c2-bc97-a810005a9654  csi             csi-snap-3936435c-a14a-4a76-9d0f-71321ac084a9  orphaned
 ```
 
+### Remote Cluster Context
+
+When PVs reside in a different Kubernetes cluster (e.g. stretched or external storage), use `--consumer-context` to look up PVs and VolumeSnapshotContents on the consumer cluster. The default is the current context, which is typically the same cluster where the CephCluster resides:
+
+```bash
+$ kubectl rook-ceph --consumer-context=consumer-cluster cephfs-snap ls
+
+Filesystem  Subvolume                                     SubvolumeGroup  Snapshot                                       State
+myfs        csi-vol-aa0099b5-f7a0-49c2-bc97-a810005a9654  csi             csi-snap-3936435c-a14a-4a76-9d0f-71321ac084a9  bound
+myfs        csi-vol-aa0099b5-f7a0-49c2-bc97-a810005a9654  csi             csi-snap-4047546d-b25b-5b87-da08-82432bd195ba  orphaned
+```
+
+```bash
+$ kubectl rook-ceph --consumer-context=consumer-cluster cephfs-snap ls --orphaned
+
+Filesystem  Subvolume                                     SubvolumeGroup  Snapshot                                       State
+myfs        csi-vol-aa0099b5-f7a0-49c2-bc97-a810005a9654  csi             csi-snap-4047546d-b25b-5b87-da08-82432bd195ba  orphaned
+```
+
 ## delete
 
 ```bash
@@ -61,4 +82,16 @@ snapshot csi-snap-b2c3d4e5-450e-11ed-8d66-0242ac110005 deleted successfully
 $ kubectl rook-ceph cephfs-snap delete myfs csi-vol-427774b4-340b-11ed-8d66-0242ac110005 csi-snap-a1b2c3d4-450e-11ed-8d66-0242ac110004
 
 Error: snapshot "csi-snap-a1b2c3d4-450e-11ed-8d66-0242ac110004" is bound and cannot be deleted
+```
+
+To delete an orphaned snapshot when PVs are on a
+consumer cluster, pass `--consumer-context`:
+
+```bash
+$ kubectl rook-ceph --consumer-context=consumer-cluster cephfs-snap delete myfs csi-vol-427774b4-340b-11ed-8d66-0242ac110005 csi-snap-b2c3d4e5-450e-11ed-8d66-0242ac110005
+
+Info: Deleting the omap object and key for snapshot "csi-snap-b2c3d4e5-450e-11ed-8d66-0242ac110005"
+Info: omap object:"csi.snap.b2c3d4e5-450e-11ed-8d66-0242ac110005" deleted
+Info: omap key:"csi.snap.snapshot-a1b2c3d4-5678-9012-abcd-ef0123456789" deleted
+snapshot "csi-snap-b2c3d4e5-450e-11ed-8d66-0242ac110005" deleted successfully
 ```

--- a/docs/cephfs-snapshots.md
+++ b/docs/cephfs-snapshots.md
@@ -22,6 +22,7 @@ The cephfs-snap command will require the following sub commands:
   * `--svg <subvolumegroupname>`: subvolume group name (default is "csi")
   * `--filesystem <filesystemname>`: lists snapshots in a particular filesystem (default is "myfs")
   * `--consumer-context <context>`: Kubernetes context for PV and VolumeSnapshotContent lookups (default is the current context)
+  * `--rados-namespace <namespace>`: rados namespace used for OMAP lookups (default is "csi")
 
 ## ls
 
@@ -82,6 +83,17 @@ snapshot csi-snap-b2c3d4e5-450e-11ed-8d66-0242ac110005 deleted successfully
 $ kubectl rook-ceph cephfs-snap delete myfs csi-vol-427774b4-340b-11ed-8d66-0242ac110005 csi-snap-a1b2c3d4-450e-11ed-8d66-0242ac110004
 
 Error: snapshot "csi-snap-a1b2c3d4-450e-11ed-8d66-0242ac110004" is bound and cannot be deleted
+```
+
+To delete using a custom rados namespace:
+
+```bash
+$ kubectl rook-ceph cephfs-snap delete csi-vol-427774b4-340b-11ed-8d66-0242ac110005 csi-snap-b2c3d4e5-450e-11ed-8d66-0242ac110005 --rados-namespace=svg01
+
+Info: Deleting the omap object and key for snapshot "csi-snap-b2c3d4e5-450e-11ed-8d66-0242ac110005"
+Info: omap object:"csi.snap.b2c3d4e5-450e-11ed-8d66-0242ac110005" deleted
+Info: omap key:"csi.snap.snapshot-a1b2c3d4-5678-9012-abcd-ef0123456789" deleted
+snapshot "csi-snap-b2c3d4e5-450e-11ed-8d66-0242ac110005" deleted successfully
 ```
 
 To delete an orphaned snapshot when PVs are on a

--- a/docs/subvolume.md
+++ b/docs/subvolume.md
@@ -12,12 +12,14 @@ The subvolume command will require the following sub commands:
   * `--stale`: lists only stale subvolumes
   * `--svg <subvolumegroupname>`: lists subvolumes in a particular subvolume(default is "csi")
   * `--consumer-context <context>`: Kubernetes context for PV and VolumeSnapshotContent lookups (default is the current context)
+  * `--rados-namespace <namespace>`: rados namespace used for OMAP lookups (default is "csi")
 * `delete <filesystem> <subvolume> [subvolumegroup]`:
     [delete](#delete) a stale subvolume.
   * subvolume: subvolume name.
   * filesystem: filesystem name to which the subvolume belongs.
   * subvolumegroup: subvolumegroup name to which the subvolume belong(default is "csi")
   * `--consumer-context <context>`: Kubernetes context for PV and VolumeSnapshotContent lookups (default is the current context)
+  * `--rados-namespace <namespace>`: rados namespace used for OMAP lookups (default is "csi")
 
 ## ls
 
@@ -82,6 +84,17 @@ Info: subvolume "csi-vol-0c91ba82-5a63-4117-88a4-690acd86cbbd" deleted
 $ kubectl rook-ceph subvolume delete myfs csi-vol-427774b4-340b-11ed-8d66-0242ac110005
 
 Info: No omapvals found for subvolume csi-vol-427774b4-340b-11ed-8d66-0242ac110005
+Info: subvolume "csi-vol-427774b4-340b-11ed-8d66-0242ac110005" deleted
+```
+
+To delete using a custom rados namespace:
+
+```bash
+$ kubectl rook-ceph subvolume delete myfs csi-vol-427774b4-340b-11ed-8d66-0242ac110005 svg01 --rados-namespace=svg01
+
+Info: Deleting the omap object and key for subvolume "csi-vol-427774b4-340b-11ed-8d66-0242ac110005"
+Info: omap object:"csi.volume.427774b4-340b-11ed-8d66-0242ac110005" deleted
+Info: omap key:"csi.volume.pvc-78abf81c-5381-42ee-8d75-dc17cd0cf5de" deleted
 Info: subvolume "csi-vol-427774b4-340b-11ed-8d66-0242ac110005" deleted
 ```
 

--- a/docs/subvolume.md
+++ b/docs/subvolume.md
@@ -11,11 +11,13 @@ The subvolume command will require the following sub commands:
 * `ls` : [ls](#ls) lists all the subvolumes
   * `--stale`: lists only stale subvolumes
   * `--svg <subvolumegroupname>`: lists subvolumes in a particular subvolume(default is "csi")
+  * `--consumer-context <context>`: Kubernetes context for PV and VolumeSnapshotContent lookups (default is the current context)
 * `delete <filesystem> <subvolume> [subvolumegroup]`:
     [delete](#delete) a stale subvolume.
   * subvolume: subvolume name.
   * filesystem: filesystem name to which the subvolume belongs.
   * subvolumegroup: subvolumegroup name to which the subvolume belong(default is "csi")
+  * `--consumer-context <context>`: Kubernetes context for PV and VolumeSnapshotContent lookups (default is the current context)
 
 ## ls
 
@@ -43,6 +45,28 @@ myfs csi-vol-427774b4-340b-11ed-8d66-0242ac110005 svg01 in-use
 myfs csi-vol-427774b4-340b-11ed-8d66-0242ac110007 svg01 stale
 ```
 
+### Remote Cluster Context
+
+When PVs reside in a different Kubernetes cluster (e.g. stretched or external storage), use `--consumer-context` to look up PVs and VolumeSnapshotContents on the consumer cluster. The default is the current context, which is typically the same cluster where the CephCluster resides:
+
+```bash
+$ kubectl rook-ceph --consumer-context=consumer-cluster subvolume ls
+
+Filesystem  Subvolume  SubvolumeGroup  State
+myfs csi-vol-427774b4-340b-11ed-8d66-0242ac110004 csi in-use
+myfs csi-vol-427774b4-340b-11ed-8d66-0242ac110005 csi in-use
+myfs csi-vol-427774b4-340b-11ed-8d66-0242ac110007 csi stale
+myfs csi-vol-427774b4-340b-11ed-8d66-0242ac110007 csi stale-with-snapshot
+```
+
+```bash
+$ kubectl rook-ceph --consumer-context=consumer-cluster subvolume ls --stale
+
+Filesystem  Subvolume  SubvolumeGroup state
+myfs csi-vol-427774b4-340b-11ed-8d66-0242ac110004 csi stale
+myfs csi-vol-427774b4-340b-11ed-8d66-0242ac110005 csi stale-with-snapshot
+```
+
 ## delete
 
 ```bash
@@ -58,5 +82,16 @@ Info: subvolume "csi-vol-0c91ba82-5a63-4117-88a4-690acd86cbbd" deleted
 $ kubectl rook-ceph subvolume delete myfs csi-vol-427774b4-340b-11ed-8d66-0242ac110005
 
 Info: No omapvals found for subvolume csi-vol-427774b4-340b-11ed-8d66-0242ac110005
+Info: subvolume "csi-vol-427774b4-340b-11ed-8d66-0242ac110005" deleted
+```
+
+To delete a stale subvolume when PVs are on a consumer cluster, pass `--consumer-context`:
+
+```bash
+$ kubectl rook-ceph --consumer-context=consumer-cluster subvolume delete myfs csi-vol-427774b4-340b-11ed-8d66-0242ac110005
+
+Info: Deleting the omap object and key for subvolume "csi-vol-427774b4-340b-11ed-8d66-0242ac110005"
+Info: omap object:"csi.volume.427774b4-340b-11ed-8d66-0242ac110005" deleted
+Info: omap key:"csi.volume.pvc-78abf81c-5381-42ee-8d75-dc17cd0cf5de" deleted
 Info: subvolume "csi-vol-427774b4-340b-11ed-8d66-0242ac110005" deleted
 ```

--- a/pkg/filesystem/snapshot.go
+++ b/pkg/filesystem/snapshot.go
@@ -89,7 +89,7 @@ func SnapshotList(ctx context.Context, clientsets *k8sutil.Clientsets, operatorN
 }
 
 // SnapshotDelete deletes a CephFS snapshot after verifying it's orphaned
-func SnapshotDelete(ctx context.Context, clientsets *k8sutil.Clientsets, operatorNamespace, clusterNamespace, fs, subvol, snap, subvolgrp string) {
+func SnapshotDelete(ctx context.Context, clientsets *k8sutil.Clientsets, operatorNamespace, clusterNamespace, fs, subvol, snap, subvolgrp, radosNamespace string) {
 	// Get snapshot IDs from Kubernetes VolumeSnapshotContent resources to check if snapshot is orphaned
 	k8sSnapshotHandles := getK8sRefSnapshotHandle(ctx, clientsets)
 
@@ -103,7 +103,7 @@ func SnapshotDelete(ctx context.Context, clientsets *k8sutil.Clientsets, operato
 		return
 	}
 
-	deleteSnapshot(ctx, clientsets, operatorNamespace, clusterNamespace, fs, subvol, subvolgrp, snap)
+	deleteSnapshot(ctx, clientsets, operatorNamespace, clusterNamespace, fs, subvol, subvolgrp, snap, radosNamespace)
 	logging.Info("snapshot %q deleted successfully", snap)
 }
 

--- a/pkg/filesystem/subvolume.go
+++ b/pkg/filesystem/subvolume.go
@@ -65,11 +65,11 @@ const (
 	snapshotRetained  = "snapshot-retained"
 )
 
-func List(ctx context.Context, clientsets *k8sutil.Clientsets, operatorNamespace, clusterNamespace, subvolg string, includeStaleOnly bool) {
+func List(ctx context.Context, clientsets *k8sutil.Clientsets, operatorNamespace, clusterNamespace, subvolg string, includeStaleOnly bool, radosNamespace string) {
 
 	subvolumeNames := getK8sRefSubvolume(ctx, clientsets)
 	snapshotHandles := getK8sRefSnapshotHandle(ctx, clientsets)
-	listCephFSSubvolumes(ctx, clientsets, operatorNamespace, clusterNamespace, subvolg, includeStaleOnly, subvolumeNames, snapshotHandles)
+	listCephFSSubvolumes(ctx, clientsets, operatorNamespace, clusterNamespace, subvolg, includeStaleOnly, subvolumeNames, snapshotHandles, radosNamespace)
 }
 
 // checkForExternalStorage checks if the external mode is enabled.
@@ -243,7 +243,7 @@ func runCommand(ctx context.Context, clientsets *k8sutil.Clientsets, operatorNam
 }
 
 // listCephFSSubvolumes list all the subvolumes
-func listCephFSSubvolumes(ctx context.Context, clientsets *k8sutil.Clientsets, operatorNamespace, clusterNamespace, subvolgName string, includeStaleOnly bool, subvolumeNames map[string]subVolumeInfo, snapshotHandles map[string]snapshotInfo) {
+func listCephFSSubvolumes(ctx context.Context, clientsets *k8sutil.Clientsets, operatorNamespace, clusterNamespace, subvolgName string, includeStaleOnly bool, subvolumeNames map[string]subVolumeInfo, snapshotHandles map[string]snapshotInfo, radosNamespace string) {
 
 	// getFilesystem gets the filesystem
 	fsstruct, err := getFileSystem(ctx, clientsets, operatorNamespace, clusterNamespace)
@@ -316,7 +316,7 @@ func listCephFSSubvolumes(ctx context.Context, clientsets *k8sutil.Clientsets, o
 						continue
 					}
 					// check if the stale subvolume has snapshots.
-					if checkSnapshot(ctx, clientsets, operatorNamespace, clusterNamespace, fs.Name, sv.Name, svg.Name, snapshotHandles) {
+					if checkSnapshot(ctx, clientsets, operatorNamespace, clusterNamespace, fs.Name, sv.Name, svg.Name, snapshotHandles, radosNamespace) {
 						status = staleWithSnapshot
 					}
 
@@ -434,7 +434,7 @@ func getFileSystem(ctx context.Context, clientsets *k8sutil.Clientsets, operator
 
 // checkSnapshot checks if there are any snapshots in the subvolume
 // it also check for the stale snapshot and if found, deletes the snapshot.
-func checkSnapshot(ctx context.Context, clientsets *k8sutil.Clientsets, operatorNamespace, clusterNamespace, fs, sv, svg string, snapshotHandles map[string]snapshotInfo) bool {
+func checkSnapshot(ctx context.Context, clientsets *k8sutil.Clientsets, operatorNamespace, clusterNamespace, fs, sv, svg string, snapshotHandles map[string]snapshotInfo, radosNamespace string) bool {
 
 	cmd := "ceph"
 	args := []string{"fs", "subvolume", "snapshot", "ls", fs, sv, svg, "--format", "json"}
@@ -455,7 +455,7 @@ func checkSnapshot(ctx context.Context, clientsets *k8sutil.Clientsets, operator
 		_, ok := snapshotHandles[snapId]
 		if !ok {
 			// delete stale snapshot
-			deleteSnapshot(ctx, clientsets, operatorNamespace, clusterNamespace, fs, sv, svg, s.Name)
+			deleteSnapshot(ctx, clientsets, operatorNamespace, clusterNamespace, fs, sv, svg, s.Name, radosNamespace)
 		}
 	}
 	if len(snap) == 0 {
@@ -492,9 +492,9 @@ func unMarshaljson(list string) []fsStruct {
 }
 
 // deleteSnapshot deletes the subvolume snapshot
-func deleteSnapshot(ctx context.Context, clientsets *k8sutil.Clientsets, operatorNamespace, cephClusterNamespace, fs, subvol, svg, snap string) {
+func deleteSnapshot(ctx context.Context, clientsets *k8sutil.Clientsets, operatorNamespace, cephClusterNamespace, fs, subvol, svg, snap, radosNamespace string) {
 
-	deleteOmapForSnapshot(ctx, clientsets, operatorNamespace, cephClusterNamespace, snap, fs)
+	deleteOmapForSnapshot(ctx, clientsets, operatorNamespace, cephClusterNamespace, snap, fs, radosNamespace)
 	cmd := "ceph"
 	args := []string{"fs", "subvolume", "snapshot", "rm", fs, subvol, snap, svg}
 
@@ -504,11 +504,11 @@ func deleteSnapshot(ctx context.Context, clientsets *k8sutil.Clientsets, operato
 	}
 }
 
-func Delete(ctx context.Context, clientsets *k8sutil.Clientsets, OperatorNamespace, CephClusterNamespace, fs, subvol, svg string) {
+func Delete(ctx context.Context, clientsets *k8sutil.Clientsets, OperatorNamespace, CephClusterNamespace, fs, subvol, svg, radosNamespace string) {
 	k8sSubvolume := getK8sRefSubvolume(ctx, clientsets)
 	_, check := k8sSubvolume[subvol]
 	if !check {
-		deleteOmapForSubvolume(ctx, clientsets, OperatorNamespace, CephClusterNamespace, subvol, fs)
+		deleteOmapForSubvolume(ctx, clientsets, OperatorNamespace, CephClusterNamespace, subvol, fs, radosNamespace)
 		cmd := "ceph"
 		args := []string{"fs", "subvolume", "rm", fs, subvol, svg, "--retain-snapshots"}
 
@@ -538,15 +538,15 @@ func getMetadataPoolName(ctx context.Context, clientsets *k8sutil.Clientsets, Op
 }
 
 // deleteOmap deletes omap object and key for the given subvolume.
-func deleteOmapForSubvolume(ctx context.Context, clientsets *k8sutil.Clientsets, OperatorNamespace, CephClusterNamespace, subVol, fs string) {
+func deleteOmapForSubvolume(ctx context.Context, clientsets *k8sutil.Clientsets, OperatorNamespace, CephClusterNamespace, subVol, fs, radosNamespace string) {
 	logging.Info("Deleting the omap object and key for subvolume %q", subVol)
-	omapkey := getOmapKey(ctx, clientsets, OperatorNamespace, CephClusterNamespace, subVol, fs)
+	omapkey := getOmapKey(ctx, clientsets, OperatorNamespace, CephClusterNamespace, subVol, fs, radosNamespace)
 	omapval, subvolId := getOmapVal(subVol)
 	poolName, err := getMetadataPoolName(ctx, clientsets, OperatorNamespace, CephClusterNamespace, fs)
 	if err != nil || poolName == "" {
 		logging.Fatal(fmt.Errorf("pool name not found: %q", err))
 	}
-	nfsClusterName := getNfsClusterName(ctx, clientsets, OperatorNamespace, CephClusterNamespace, subVol, fs)
+	nfsClusterName := getNfsClusterName(ctx, clientsets, OperatorNamespace, CephClusterNamespace, subVol, fs, radosNamespace)
 	if nfsClusterName != "" {
 		exportPath := getNfsExportPath(ctx, clientsets, OperatorNamespace, CephClusterNamespace, nfsClusterName, subvolId)
 		if exportPath == "" {
@@ -563,34 +563,34 @@ func deleteOmapForSubvolume(ctx context.Context, clientsets *k8sutil.Clientsets,
 	}
 	if omapval != "" {
 		cmd := "rados"
-		args := []string{"rm", omapval, "-p", poolName, "--namespace", "csi"}
+		args := []string{"rm", omapval, "-p", poolName, "--namespace", radosNamespace}
 
 		// remove omap object.
 		_, err := runCommand(ctx, clientsets, OperatorNamespace, CephClusterNamespace, cmd, args)
 		if err != nil {
-			logging.Fatal(err, "failed to remove omap object for subvolume %q", subVol)
+			logging.Warning("failed to remove omap object for subvolume %q: %v", subVol, err)
+		} else {
+			logging.Info("omap object:%q deleted", omapval)
 		}
-		logging.Info("omap object:%q deleted", omapval)
-
 	}
 	if omapkey != "" {
 		cmd := "rados"
-		args := []string{"rmomapkey", "csi.volumes.default", omapkey, "-p", poolName, "--namespace", "csi"}
+		args := []string{"rmomapkey", "csi.volumes.default", omapkey, "-p", poolName, "--namespace", radosNamespace}
 
 		// remove omap key.
 		_, err := runCommand(ctx, clientsets, OperatorNamespace, CephClusterNamespace, cmd, args)
 		if err != nil {
-			logging.Fatal(err, "failed to remove omap key for subvolume %q", subVol)
+			logging.Warning("failed to remove omap key for subvolume %q: %v", subVol, err)
+		} else {
+			logging.Info("omap key:%q deleted", omapkey)
 		}
-		logging.Info("omap key:%q deleted", omapkey)
-
 	}
 }
 
 // deleteOmapForSnapshot deletes omap object and key for the given snapshot.
-func deleteOmapForSnapshot(ctx context.Context, clientsets *k8sutil.Clientsets, OperatorNamespace, CephClusterNamespace, snap, fs string) {
+func deleteOmapForSnapshot(ctx context.Context, clientsets *k8sutil.Clientsets, OperatorNamespace, CephClusterNamespace, snap, fs, radosNamespace string) {
 	logging.Info("Deleting the omap object and key for snapshot %q", snap)
-	snapomapkey := getSnapOmapKey(ctx, clientsets, OperatorNamespace, CephClusterNamespace, snap, fs)
+	snapomapkey := getSnapOmapKey(ctx, clientsets, OperatorNamespace, CephClusterNamespace, snap, fs, radosNamespace)
 	snapomapval, _ := getSnapOmapVal(snap)
 	poolName, err := getMetadataPoolName(ctx, clientsets, OperatorNamespace, CephClusterNamespace, fs)
 	if err != nil || poolName == "" {
@@ -598,26 +598,26 @@ func deleteOmapForSnapshot(ctx context.Context, clientsets *k8sutil.Clientsets, 
 	}
 	cmd := "rados"
 	if snapomapval != "" {
-		args := []string{"rm", snapomapval, "-p", poolName, "--namespace", "csi"}
+		args := []string{"rm", snapomapval, "-p", poolName, "--namespace", radosNamespace}
 
 		// remove omap object.
 		_, err := runCommand(ctx, clientsets, OperatorNamespace, CephClusterNamespace, cmd, args)
 		if err != nil {
-			logging.Fatal(err, "failed to remove omap object for snapshot %q", snap)
+			logging.Warning("failed to remove omap object for snapshot %q: %v", snap, err)
+		} else {
+			logging.Info("omap object:%q deleted", snapomapval)
 		}
-		logging.Info("omap object:%q deleted", snapomapval)
-
 	}
 	if snapomapkey != "" {
-		args := []string{"rmomapkey", "csi.snaps.default", snapomapkey, "-p", poolName, "--namespace", "csi"}
+		args := []string{"rmomapkey", "csi.snaps.default", snapomapkey, "-p", poolName, "--namespace", radosNamespace}
 
 		// remove omap key.
 		_, err := runCommand(ctx, clientsets, OperatorNamespace, CephClusterNamespace, cmd, args)
 		if err != nil {
-			logging.Fatal(err, "failed to remove omap key for snapshot %q", snap)
+			logging.Warning("failed to remove omap key for snapshot %q: %v", snap, err)
+		} else {
+			logging.Info("omap key:%q deleted", snapomapkey)
 		}
-		logging.Info("omap key:%q deleted", snapomapkey)
-
 	}
 }
 
@@ -627,7 +627,7 @@ func deleteOmapForSnapshot(ctx context.Context, clientsets *k8sutil.Clientsets, 
 // deleted.
 // similarly to delete of omap key requires csi.volume.ompakey, where
 // omapkey is the pv name which is extracted the omap object.
-func getOmapKey(ctx context.Context, clientsets *k8sutil.Clientsets, OperatorNamespace, CephClusterNamespace, subVol, fs string) string {
+func getOmapKey(ctx context.Context, clientsets *k8sutil.Clientsets, OperatorNamespace, CephClusterNamespace, subVol, fs, radosNamespace string) string {
 
 	poolName, err := getMetadataPoolName(ctx, clientsets, OperatorNamespace, CephClusterNamespace, fs)
 	if err != nil || poolName == "" {
@@ -635,7 +635,7 @@ func getOmapKey(ctx context.Context, clientsets *k8sutil.Clientsets, OperatorNam
 	}
 	omapval, _ := getOmapVal(subVol)
 
-	args := []string{"getomapval", omapval, "csi.volname", "-p", poolName, "--namespace", "csi", "/dev/stdout"}
+	args := []string{"getomapval", omapval, "csi.volname", "-p", poolName, "--namespace", radosNamespace, "/dev/stdout"}
 	cmd := "rados"
 	pvname, err := runCommand(ctx, clientsets, OperatorNamespace, CephClusterNamespace, cmd, args)
 	if err != nil || pvname == "" {
@@ -654,7 +654,7 @@ func getOmapKey(ctx context.Context, clientsets *k8sutil.Clientsets, OperatorNam
 // csi.snap.snapid.
 // similarly to delete of omap key requires csi.snap.ompakey, where
 // omapkey is the snapshotcontent name which is extracted the omap object.
-func getSnapOmapKey(ctx context.Context, clientsets *k8sutil.Clientsets, operatorNamespace, cephClusterNamespace, snap, fs string) string {
+func getSnapOmapKey(ctx context.Context, clientsets *k8sutil.Clientsets, operatorNamespace, cephClusterNamespace, snap, fs, radosNamespace string) string {
 
 	poolName, err := getMetadataPoolName(ctx, clientsets, operatorNamespace, cephClusterNamespace, fs)
 	if err != nil || poolName == "" {
@@ -662,7 +662,7 @@ func getSnapOmapKey(ctx context.Context, clientsets *k8sutil.Clientsets, operato
 	}
 	snapomapval, _ := getSnapOmapVal(snap)
 
-	args := []string{"getomapval", snapomapval, "csi.snapname", "-p", poolName, "--namespace", "csi", "/dev/stdout"}
+	args := []string{"getomapval", snapomapval, "csi.snapname", "-p", poolName, "--namespace", radosNamespace, "/dev/stdout"}
 	cmd := "rados"
 	snapshotcontentname, err := runCommand(ctx, clientsets, operatorNamespace, cephClusterNamespace, cmd, args)
 	if snapshotcontentname == "" && err == nil {
@@ -685,7 +685,7 @@ func getSnapOmapKey(ctx context.Context, clientsets *k8sutil.Clientsets, operato
 // 00000000  6f 63 73 2d 73 74 6f 72  61 67 65 63 6c 75 73 74  |my-cluster-cephn|
 // 00000010  65 72 2d 63 65 70 68 6e  66 73                    |fs|
 // 0000001a
-func getNfsClusterName(ctx context.Context, clientsets *k8sutil.Clientsets, OperatorNamespace, CephClusterNamespace, subVol, fs string) string {
+func getNfsClusterName(ctx context.Context, clientsets *k8sutil.Clientsets, OperatorNamespace, CephClusterNamespace, subVol, fs, radosNamespace string) string {
 
 	poolName, err := getMetadataPoolName(ctx, clientsets, OperatorNamespace, CephClusterNamespace, fs)
 	if err != nil || poolName == "" {
@@ -693,7 +693,7 @@ func getNfsClusterName(ctx context.Context, clientsets *k8sutil.Clientsets, Oper
 	}
 	omapval, _ := getOmapVal(subVol)
 
-	args := []string{"getomapval", omapval, "csi.nfs.cluster", "-p", poolName, "--namespace", "csi", "/dev/stdout"}
+	args := []string{"getomapval", omapval, "csi.nfs.cluster", "-p", poolName, "--namespace", radosNamespace, "/dev/stdout"}
 	cmd := "rados"
 	nfscluster, err := runCommand(ctx, clientsets, OperatorNamespace, CephClusterNamespace, cmd, args)
 	if err != nil || nfscluster == "" {

--- a/pkg/filesystem/subvolume.go
+++ b/pkg/filesystem/subvolume.go
@@ -133,7 +133,7 @@ func getExternalClusterDetails(ctx context.Context, clientsets *k8sutil.Clientse
 
 // getk8sRefSubvolume returns the k8s ref for the subvolumes
 func getK8sRefSubvolume(ctx context.Context, clientsets *k8sutil.Clientsets) map[string]subVolumeInfo {
-	pvList, err := clientsets.Kube.CoreV1().PersistentVolumes().List(ctx, v1.ListOptions{})
+	pvList, err := clientsets.ConsumerKube.CoreV1().PersistentVolumes().List(ctx, v1.ListOptions{})
 	if err != nil {
 		logging.Fatal(fmt.Errorf("Error fetching PVs: %v\n", err))
 	}
@@ -187,7 +187,7 @@ func generateSubvolumeNameFromVolumeHandle(prefix string, volumeHandle string) (
 // getk8sRefSnapshotHandle returns the snapshothandle for k8s ref of the volume snapshots
 func getK8sRefSnapshotHandle(ctx context.Context, clientsets *k8sutil.Clientsets) map[string]snapshotInfo {
 
-	snapConfig, err := snapclient.NewForConfig(clientsets.KubeConfig)
+	snapConfig, err := snapclient.NewForConfig(clientsets.ConsumerConfig)
 	if err != nil {
 		logging.Fatal(err)
 	}

--- a/pkg/filesystem/subvolume_test.go
+++ b/pkg/filesystem/subvolume_test.go
@@ -18,10 +18,91 @@ package filesystem
 
 import (
 	"fmt"
+	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestIsSubvolumeNotReady(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "EAGAIN errno",
+			err:      syscall.EAGAIN,
+			expected: true,
+		},
+		{
+			name:     "string contains EAGAIN",
+			err:      fmt.Errorf("operation failed: EAGAIN"),
+			expected: true,
+		},
+		{
+			name:     "exit code 11 in message",
+			err:      fmt.Errorf("command failed: exit status 11"),
+			expected: true,
+		},
+		{
+			name:     "exit code -11 in message",
+			err:      fmt.Errorf("command failed: exit status -11"),
+			expected: true,
+		},
+		{
+			name:     "exit code 11 text variant",
+			err:      fmt.Errorf("command failed: exit code 11"),
+			expected: true,
+		},
+		{
+			name:     "unrelated error",
+			err:      fmt.Errorf("some other error"),
+			expected: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isSubvolumeNotReady(tt.err))
+		})
+	}
+}
+
+func TestExitCodeFromError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		code int
+		ok   bool
+	}{
+		{
+			name: "errno EAGAIN",
+			err:  syscall.EAGAIN,
+			code: int(syscall.EAGAIN),
+			ok:   true,
+		},
+		{
+			name: "non-errno error",
+			err:  fmt.Errorf("plain error"),
+			code: 0,
+			ok:   false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			code, ok := exitCodeFromError(tt.err)
+			assert.Equal(t, tt.ok, ok)
+			if ok {
+				assert.Equal(t, tt.code, code)
+			}
+		})
+	}
+}
 
 func TestGetOmapVal(t *testing.T) {
 

--- a/pkg/k8sutil/context.go
+++ b/pkg/k8sutil/context.go
@@ -36,4 +36,12 @@ type Clientsets struct {
 
 	// Dynamic is used for manage dynamic resources
 	Dynamic dynamic.Interface
+
+	// ConsumerConfig is the rest config for PV and VolumeSnapshotContent lookups on the
+	// consumer cluster. Defaults to KubeConfig when --consumer-context is not set.
+	ConsumerConfig *rest.Config
+
+	// ConsumerKube is the K8s client for PV and VolumeSnapshotContent lookups on the
+	// consumer cluster. Defaults to Kube when --consumer-context is not set.
+	ConsumerKube kubernetes.Interface
 }

--- a/tests/github-action-helper.sh
+++ b/tests/github-action-helper.sh
@@ -544,6 +544,47 @@ wait_for_rbd_pvc_clone_to_be_bound() {
     kubectl wait --for=jsonpath='{.status.phase}'=Bound pvc rbd-pvc-clone --timeout=600s
 }
 
+# Create a consumer kubeconfig context that aliases the current cluster.
+# Used to test --consumer-context flag with a single Minikube cluster.
+create_consumer_context() {
+    local context_name="${1:-consumer-ctx}"
+    local current_ctx
+    current_ctx="$(kubectl config current-context)"
+
+    local cluster server ca_cert
+    cluster="$(kubectl config view -o jsonpath="{.contexts[?(@.name=='${current_ctx}')].context.cluster}")"
+    server="$(kubectl config view -o jsonpath="{.clusters[?(@.name=='${cluster}')].cluster.server}")"
+    ca_cert="$(kubectl config view --raw -o jsonpath="{.clusters[?(@.name=='${cluster}')].cluster.certificate-authority}")"
+    local ca_data
+    ca_data="$(kubectl config view --raw -o jsonpath="{.clusters[?(@.name=='${cluster}')].cluster.certificate-authority-data}")"
+
+    kubectl config set-cluster "${context_name}-cluster" --server="${server}"
+    if [[ -n "$ca_cert" ]]; then
+        kubectl config set-cluster "${context_name}-cluster" --certificate-authority="${ca_cert}"
+    elif [[ -n "$ca_data" ]]; then
+        kubectl config set clusters."${context_name}-cluster".certificate-authority-data "${ca_data}"
+    fi
+
+    local user
+    user="$(kubectl config view -o jsonpath="{.contexts[?(@.name=='${current_ctx}')].context.user}")"
+    local client_cert client_key client_cert_data client_key_data
+    client_cert="$(kubectl config view --raw -o jsonpath="{.users[?(@.name=='${user}')].user.client-certificate}")"
+    client_key="$(kubectl config view --raw -o jsonpath="{.users[?(@.name=='${user}')].user.client-key}")"
+    client_cert_data="$(kubectl config view --raw -o jsonpath="{.users[?(@.name=='${user}')].user.client-certificate-data}")"
+    client_key_data="$(kubectl config view --raw -o jsonpath="{.users[?(@.name=='${user}')].user.client-key-data}")"
+
+    kubectl config set-credentials "${context_name}-user"
+    if [[ -n "$client_cert" ]]; then
+        kubectl config set-credentials "${context_name}-user" --client-certificate="${client_cert}" --client-key="${client_key}"
+    elif [[ -n "$client_cert_data" ]]; then
+        kubectl config set users."${context_name}-user".client-certificate-data "${client_cert_data}"
+        kubectl config set users."${context_name}-user".client-key-data "${client_key_data}"
+    fi
+
+    kubectl config set-context "${context_name}" --cluster="${context_name}-cluster" --user="${context_name}-user"
+    echo "Created consumer context: ${context_name}"
+}
+
 ########
 # MAIN #
 ########

--- a/tests/github-action-helper.sh
+++ b/tests/github-action-helper.sh
@@ -356,6 +356,95 @@ delete_cephfs_snapshot_k8s_resources() {
 }
 
 
+# Create a CephFilesystemSubVolumeGroup, a matching Retain StorageClass
+# (with subvolumeGroup set to the svg name), and a stale subvolume for
+# testing --svg flag.  CephFS CSI stores OMAP entries in the "csi" rados
+# namespace by default (configured at cluster level in the CSI ConfigMap,
+# NOT per-StorageClass).  After this call the subvolume exists in Ceph
+# but has no k8s PVC reference (stale).
+# Args: $1 svg-name  $2 operator-ns  $3 cluster-ns
+create_stale_subvolume_in_svg() {
+    local svg="${1:-test-svg}"
+    local operator_ns="${2:-$DEFAULT_OPERATOR_NS}"
+    local cluster_ns="${3:-$DEFAULT_CLUSTER_NS}"
+    local sc_name="rook-cephfs-${svg}-retain"
+    local pvc_name="cephfs-pvc-${svg}"
+
+    # 1. Create the CephFilesystemSubVolumeGroup CR
+    cat > "svg-${svg}.yaml" <<EOF
+apiVersion: ceph.rook.io/v1
+kind: CephFilesystemSubVolumeGroup
+metadata:
+  name: ${svg}
+  namespace: ${cluster_ns}
+spec:
+  filesystemName: myfs
+EOF
+    kubectl create -f "svg-${svg}.yaml"
+    kubectl wait --for=jsonpath='{.status.phase}'=Ready \
+        CephFilesystemSubVolumeGroup "${svg}" -n "${cluster_ns}" \
+        --timeout="${DEFAULT_TIMEOUT}s"
+
+    # Restart the CephFS CSI provisioner so it immediately reloads the
+    # Rook ConfigMap containing the new clusterID. Without this, the
+    # provisioner relies on the kubelet ConfigMap sync delay (~1-2 min)
+    # plus external-provisioner exponential backoff (max 5 min), causing
+    # PVC binding to stall for ~8 minutes in custom-namespace CI.
+    # The deployment name is "<operator_ns>.cephfs.csi.ceph.com-ctrlplugin".
+    local cephfs_deploy="${operator_ns}.cephfs.csi.ceph.com-ctrlplugin"
+    kubectl rollout restart deployment "${cephfs_deploy}" -n "${operator_ns}"
+    kubectl rollout status deployment "${cephfs_deploy}" \
+        -n "${operator_ns}" --timeout=120s
+
+    # 2. Get the CSI clusterID from the SVG status.
+    # Returns spec.clusterID if set, otherwise the auto-generated one.
+    local cluster_id
+    cluster_id=$(kubectl -n "${cluster_ns}" \
+        get cephfilesystemsubvolumegroup "${svg}" \
+        -o jsonpath="{.status.info.clusterID}")
+
+    # 3. Build a Retain StorageClass for this SVG.
+    # CephFS CSI does not support radosNamespace per-StorageClass;
+    # OMAP is always in the "csi" rados namespace (CSI ConfigMap default).
+    download_and_modify_yaml \
+        "https://raw.githubusercontent.com/rook/rook/master/deploy/examples/csi/cephfs/storageclass.yaml" \
+        "storageclass-${svg}.yaml" "$operator_ns" "$cluster_ns"
+    sed -i "s|name: rook-cephfs|name: ${sc_name}|g" \
+        "storageclass-${svg}.yaml"
+    sed -i "s|clusterID: .*|clusterID: ${cluster_id}|g" \
+        "storageclass-${svg}.yaml"
+    sed -i "s|reclaimPolicy: Delete|reclaimPolicy: Retain|g" \
+        "storageclass-${svg}.yaml"
+    if [[ "$operator_ns" != "$DEFAULT_OPERATOR_NS" ]]; then
+        sed -i "s|provisioner: rook-ceph.cephfs.csi.ceph.com|provisioner: ${operator_ns}.cephfs.csi.ceph.com|g" \
+            "storageclass-${svg}.yaml"
+    fi
+    kubectl create -f "storageclass-${svg}.yaml"
+
+    # 4. Create PVC to provision a subvolume in the SVG
+    cat > "pvc-${svg}.yaml" <<EOF
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ${pvc_name}
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: ${sc_name}
+EOF
+    kubectl create -f "pvc-${svg}.yaml"
+    wait_for_pvc_to_be_bound_state "${pvc_name}" "default"
+
+    # 5. Delete PVC; PV is retained so subvolume becomes stale
+    local pv_name
+    pv_name="$(kubectl get pvc "${pvc_name}" -o=jsonpath='{.spec.volumeName}')"
+    kubectl delete pvc "${pvc_name}"
+    kubectl delete pv "${pv_name}"
+}
+
 #################
 # WAIT FUNCTIONS
 #################


### PR DESCRIPTION
**Description:**

- core: add --consumer-context flag for cross-cluster PVC/Snap lookups

Add a `--consumer-context` global flag that allows PV and VolumeSnapshotContent lookups to target a different
Kubernetes cluster context while Ceph commands execute in the default context.

This supports stretched/external storage scenarios where PVs exist in a consumer cluster separate
from the Ceph cluster. When omitted, behavior is identical to before (consumer clients alias the primary). Currently wired for `subvolume ls` and `subvolume delete` commands.

- test: add integration tests for --consumer-context flag

Adds integration tests with a `create_consumer_context()` helper that creates a kubeconfig
context alias for single-cluster CI testing, verifying `subvolume ls` works with a
valid consumer context and fails cleanly with an invalid one.

---
- core: add --rados-namespace flag to subvolume commands

Add --rados-namespace as a PersistentFlag on the subvolume command so both ls and delete inherit it. The flag specifies the rados namespace for OMAP object/key lookups (default "csi").

Thread radosNamespace through the full snapshot OMAP call chain:
List → listCephFSSubvolumes → checkSnapshot → deleteSnapshot → deleteOmapForSnapshot and getSnapOmapKey, replacing previously hardcoded "csi" values.

Also add unit tests for isSubvolumeNotReady and exitCodeFromError, and update docs with --rados-namespace usage examples.

- test: add integration test for subvolume delete with custom SVG

Add create_stale_subvolume_in_svg() helper that creates a CephFilesystemSubVolumeGroup CR, reads status.info.clusterID, builds a Retain StorageClass with subvolumeGroup set to the SVG
name, then creates and deletes a PVC to produce a stale subvolume.



**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and
  messages follow guidelines in the
  [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on
  [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
