### PR TITLE
update getSnapshotHandleId to correctly retrieve snapshotID

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,14 @@ These are args currently supported:
 - `dr` :
   - `health [ceph status args]`: Print the `ceph status` of a peer cluster in a mirroring-enabled environment thereby validating connectivity between ceph clusters. Ceph status args can be optionally passed, such as to change the log level: `--debug-ms 1`.
 
+- `subvolume` : Identify and clean up stale subvolumes that have no parent PV.
+  - `ls [--stale] [--svg <group>]` : List all subvolumes and their state (in-use, stale, stale-with-snapshot)
+  - `delete <filesystem> <subvolume> [subvolumegroup]` : Delete a stale subvolume and its OMAP metadata
+
+- `cephfs-snap` : Identify and clean up orphaned snapshots that have no corresponding VolumeSnapshotContent.
+  - `ls [--orphaned] [--filesystem <fs>] [--svg <group>]` : List all snapshots and their state (bound, orphaned)
+  - `delete <filesystem> <subvolume> <snapshot> [--svg <group>]` : Delete an orphaned snapshot and its OMAP metadata
+
 - `restore-deleted <CRD> [CRName]`: Restore the ceph resources which are stuck in deleting state due to underlying resources being present in the cluster
 
 - `multus validation` : Validate whether the current Multus and system configurations will support Rook with Multus. See [Validating Multus configuration](https://rook.github.io/docs/rook/latest/CRDs/Cluster/network-providers/?h=valid#validating-multus-configuration) for more details.
@@ -118,6 +126,8 @@ Visit docs below for complete details about each command and their flags uses.
 1. [Destroy cluster](docs/destroy-cluster.md)
 1. [Running rados commands](docs/rados.md)
 1. [Multus validation](docs/multus.md)
+1. [Subvolume cleanup](docs/subvolume.md)
+1. [Snapshot cleanup](docs/cephfs-snapshots.md)
 
 ## Examples
 

--- a/pkg/filesystem/subvolume.go
+++ b/pkg/filesystem/subvolume.go
@@ -165,7 +165,7 @@ func (f *CephFilesystem) getK8sRefSubvolume() map[string]subVolumeInfo {
 			if strings.Contains(driverName, "cephfs.csi.ceph.com") {
 				volumeHandle := pv.Spec.CSI.VolumeHandle
 				prefix := pv.Spec.CSI.VolumeAttributes["volumeNamePrefix"]
-				name, err := generateSubvolumeNameFromVolumeHandle(prefix, volumeHandle)
+				name, err := generateResourceNameFromCSIHandle(prefix, volumeHandle, "csi-vol-")
 				if err != nil {
 					logging.Error(err, "failed to get subvolume name")
 					continue
@@ -177,17 +177,18 @@ func (f *CephFilesystem) getK8sRefSubvolume() map[string]subVolumeInfo {
 	return subvolumeNames
 }
 
-// generateSubvolumeNameFromVolumeHandle constructs a subvolume name using the given prefix and volume handle.
-// If the prefix is empty, the function extracts the version from the volume handle.
-// When the version is `1`, the prefix is set to `csi-vol-`.
-// Ref: https://github.com/ceph/ceph-csi/blob/72c09d3d8758d058575d34b2da4b09eb0a591f8f/internal/util/volid.go#L65-L77
-// Example:
-// volumeHandle: 0001-0011-openshift-storage-0000000000000001-aac40941-9b54-432f-8a63-3b1614a4e024
-// prefix: ""
-// subvolumeName: csi-vol-aac40941-9b54-432f-8a63-3b1614a4e024
-func generateSubvolumeNameFromVolumeHandle(prefix string, volumeHandle string) (string, error) {
+// generateResourceNameFromCSIHandle constructs a Ceph resource name from a CSI handle.
+// Both volume handles and snapshot handles share the same encoding:
+// <version:4hex>-<clusterIDLen:4hex>-<clusterID:variable>-<poolID:16hex>-<uuid:36chars>
+// Examples:
+// handle: 0001-0011-openshift-storage-0000000000000001-aac40941-9b54-432f-8a63-3b1614a4e024
+// prefix: "", defaultPrefix: "csi-vol-"  →  csi-vol-aac40941-9b54-432f-8a63-3b1614a4e024
+//
+// handle: 0001-0009-rook-ceph-0000000000000001-17b95621-58e8-4676-bc6a-39e928f19d23
+// prefix: "", defaultPrefix: "csi-snap-" →  csi-snap-17b95621-58e8-4676-bc6a-39e928f19d23
+func generateResourceNameFromCSIHandle(prefix, volumeHandle, defaultPrefix string) (string, error) {
 	if len(volumeHandle) < 36 {
-		return "", fmt.Errorf("volume handle too short to extract subvolume name: %s", volumeHandle)
+		return "", fmt.Errorf("CSI handle too short to extract resource name: %s", volumeHandle)
 	}
 	if prefix == "" {
 		version, err := strconv.ParseInt(volumeHandle[:4], 16, 0)
@@ -197,7 +198,7 @@ func generateSubvolumeNameFromVolumeHandle(prefix string, volumeHandle string) (
 		if version != 1 {
 			return "", fmt.Errorf("failed to extract prefix: volume handle %q uses an unsupported version format", volumeHandle)
 		}
-		prefix = "csi-vol-"
+		prefix = defaultPrefix
 	}
 	uuid := volumeHandle[len(volumeHandle)-36:]
 
@@ -225,29 +226,17 @@ func (f *CephFilesystem) getK8sRefSnapshotHandle() map[string]snapshotInfo {
 	for _, snap := range snapList.Items {
 		driverName := snap.Spec.Driver
 		if snap.Status != nil && snap.Status.SnapshotHandle != nil && strings.Contains(driverName, "cephfs.csi.ceph.com") {
-			snapshotHandleId := getSnapshotHandleId(*snap.Status.SnapshotHandle)
-			// map the snapshotHandle id to later lookup for the subvol id and
-			// match the subvolume snapshot.
-			snapshotHandles[snapshotHandleId] = snapshotInfo{}
+			snapshotName, err := generateResourceNameFromCSIHandle("", *snap.Status.SnapshotHandle, "csi-snap-")
+			if err != nil {
+				logging.Warning("skipping VolumeSnapshotContent %q: could not parse snapshot handle %q", snap.Name, *snap.Status.SnapshotHandle)
+				continue
+			}
+			_, snapshotHandleID := getSnapOmapVal(snapshotName)
+			snapshotHandles[snapshotHandleID] = snapshotInfo{}
 		}
 	}
 
 	return snapshotHandles
-}
-
-// getSnapshotHandleId gets the id from snapshothandle
-// SnapshotHandle: 0001-0009-rook-ceph-0000000000000001-17b95621-
-// 58e8-4676-bc6a-39e928f19d23
-// SnapshotHandleId: 17b95621-58e8-4676-bc6a-39e928f19d23
-func getSnapshotHandleId(snapshotHandle string) string {
-	// get the snaps id from snapshot handle
-	splitSnapshotHandle := strings.SplitAfterN(snapshotHandle, "-", 6)
-	if len(splitSnapshotHandle) < 6 {
-		return ""
-	}
-	snapshotHandleId := splitSnapshotHandle[len(splitSnapshotHandle)-1]
-
-	return snapshotHandleId
 }
 
 // runCommand checks for the presence of externalcluster and runs the command accordingly.

--- a/pkg/filesystem/subvolume_test.go
+++ b/pkg/filesystem/subvolume_test.go
@@ -146,40 +146,51 @@ func TestGetOmapVal(t *testing.T) {
 	}
 }
 
-func TestGenerateSubvolumeNameFromVolumeHandle(t *testing.T) {
+func TestGenerateResourceNameFromCSIHandle(t *testing.T) {
 
 	tests := []struct {
-		prefix       string
-		volumeHandle string
-		name         string
-		err          error
+		prefix        string
+		volumeHandle  string
+		defaultPrefix string
+		name          string
+		err           error
 	}{
 		{
-			prefix:       "myvol-",
-			volumeHandle: "0001-0011-openshift-storage-0000000000000001-aac40941-9b54-432f-8a63-3b1614a4e024",
-			name:         "myvol-aac40941-9b54-432f-8a63-3b1614a4e024",
+			prefix:        "myvol-",
+			volumeHandle:  "0001-0011-openshift-storage-0000000000000001-aac40941-9b54-432f-8a63-3b1614a4e024",
+			defaultPrefix: "csi-vol-",
+			name:          "myvol-aac40941-9b54-432f-8a63-3b1614a4e024",
 		},
 		{
-			volumeHandle: "0001-0011-openshift-storage-0000000000000001-aac40941-9b54-432f-8a63-3b1614a4e024",
-			name:         "csi-vol-aac40941-9b54-432f-8a63-3b1614a4e024",
+			volumeHandle:  "0001-0011-openshift-storage-0000000000000001-aac40941-9b54-432f-8a63-3b1614a4e024",
+			defaultPrefix: "csi-vol-",
+			name:          "csi-vol-aac40941-9b54-432f-8a63-3b1614a4e024",
 		},
 		{
-			volumeHandle: "0001-0009-rook-ceph-0000000000000001-aac40941-9b54-432f-8a63-3b1614a4e024",
-			name:         "csi-vol-aac40941-9b54-432f-8a63-3b1614a4e024",
+			volumeHandle:  "0001-0009-rook-ceph-0000000000000001-aac40941-9b54-432f-8a63-3b1614a4e024",
+			defaultPrefix: "csi-vol-",
+			name:          "csi-vol-aac40941-9b54-432f-8a63-3b1614a4e024",
 		},
 		{
-			prefix:       "",
-			volumeHandle: "0002-0009-rook-ceph-0000000000000001-aac40941-9b54-432f-8a63-3b1614a4e024",
-			err:          fmt.Errorf("failed to extract prefix: volume handle \"0002-0009-rook-ceph-0000000000000001-aac40941-9b54-432f-8a63-3b1614a4e024\" uses an unsupported version format"),
+			volumeHandle:  "0001-0009-rook-ceph-0000000000000001-aac40941-9b54-432f-8a63-3b1614a4e024",
+			defaultPrefix: "csi-snap-",
+			name:          "csi-snap-aac40941-9b54-432f-8a63-3b1614a4e024",
 		},
 		{
-			volumeHandle: "ac40941-9b54-432f-8a63-3b1614a4e024",
-			err:          fmt.Errorf("volume handle too short to extract subvolume name: ac40941-9b54-432f-8a63-3b1614a4e024"),
+			prefix:        "",
+			volumeHandle:  "0002-0009-rook-ceph-0000000000000001-aac40941-9b54-432f-8a63-3b1614a4e024",
+			defaultPrefix: "csi-vol-",
+			err:           fmt.Errorf("failed to extract prefix: volume handle \"0002-0009-rook-ceph-0000000000000001-aac40941-9b54-432f-8a63-3b1614a4e024\" uses an unsupported version format"),
+		},
+		{
+			volumeHandle:  "ac40941-9b54-432f-8a63-3b1614a4e024",
+			defaultPrefix: "csi-vol-",
+			err:           fmt.Errorf("CSI handle too short to extract resource name: ac40941-9b54-432f-8a63-3b1614a4e024"),
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.volumeHandle, func(t *testing.T) {
-			name, err := generateSubvolumeNameFromVolumeHandle(tt.prefix, tt.volumeHandle)
+			name, err := generateResourceNameFromCSIHandle(tt.prefix, tt.volumeHandle, tt.defaultPrefix)
 			if err != nil {
 				assert.Error(t, err)
 				assert.Equal(t, tt.err.Error(), err.Error())
@@ -227,34 +238,3 @@ func TestGetSnapOmapVal(t *testing.T) {
 	}
 }
 
-func TestGetSnapshotHandleId(t *testing.T) {
-
-	tests := []struct {
-		name string
-		val  string
-	}{
-		{
-			name: "0001-0009-rook-ceph-0000000000000001-17b95621-58e8-4676-bc6a-39e928f19d23",
-			val:  "17b95621-58e8-4676-bc6a-39e928f19d23",
-		},
-		{
-			name: "",
-			val:  "",
-		},
-		{
-			name: "0001-0009-rook-0000000000000001-17b95621-58e8-4676-bc6a-39e928f19d23",
-			val:  "58e8-4676-bc6a-39e928f19d23",
-		},
-		{
-			name: "rook-427774b440b11ed8d660242ac11000",
-			val:  "",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if val := getSnapshotHandleId(tt.name); val != tt.val {
-				assert.Equal(t, val, tt.val)
-			}
-		})
-	}
-}


### PR DESCRIPTION
<!-- Thank you for contributing to Rook! -->
Problem statement: 
Snapshot handles with UUID-based clusterIDs were being parsed incorrectly, causing the snapshot ID extraction to fail. This resulted in bound snapshots being reported as orphaned.

Solution: 
Using binary encoding to decode the snapshot ID from the handle instead of assuming a fixed number of dashes.

The PR also adds the subvolume and snapshot commands to the `README.md` file. 
