### PR TITLE
ci: test custom namespace flaky test

### DIFF
--- a/.github/workflows/go-test-config/action.yaml
+++ b/.github/workflows/go-test-config/action.yaml
@@ -77,18 +77,6 @@ runs:
         set -ex
         kubectl rook-ceph ${NS_OPT} radosgw-admin user create --display-name="johnny rotten" --uid=johnny
 
-    - name: Mon restore
-      shell: bash --noprofile --norc -eo pipefail -x {0}
-      run: |
-        set -ex
-        # test the mon restore to restore to mon a, delete mons b and c, then add d and e
-        kubectl rook-ceph ${NS_OPT} mons restore-quorum a
-        kubectl -n ${{ inputs.cluster-ns }} wait pod -l app=rook-ceph-mon-b --for=delete --timeout=90s
-        kubectl -n ${{ inputs.cluster-ns }} wait pod -l app=rook-ceph-mon-c --for=delete --timeout=90s
-        tests/github-action-helper.sh wait_for_three_mons ${{ inputs.cluster-ns }}
-        kubectl -n ${{ inputs.cluster-ns }} wait deployment rook-ceph-mon-d --for condition=Available=True --timeout=90s
-        kubectl -n ${{ inputs.cluster-ns }} wait deployment rook-ceph-mon-e --for condition=Available=True --timeout=90s
-
     - name: Rbd command
       shell: bash --noprofile --norc -eo pipefail -x {0}
       run: |
@@ -121,7 +109,7 @@ runs:
         CLUSTER_NS=${{ inputs.cluster-ns }}
         OP_NS=${{ inputs.op-ns }}
         POD_NAME=$(kubectl -n "$OP_NS" get pod \
-            -l "app=${OP_NS}.cephfs.csi.ceph.com-ctrlplugin" \
+            -l "app=rook-ceph.cephfs.csi.ceph.com-ctrlplugin" \
             -o jsonpath='{.items[0].metadata.name}')
         POD_NS="$OP_NS"
         CONTAINER="csi-cephfsplugin"
@@ -170,7 +158,7 @@ runs:
         CLUSTER_NS=${{ inputs.cluster-ns }}
         OP_NS=${{ inputs.op-ns }}
         POD_NAME=$(kubectl -n "$OP_NS" get pod \
-            -l "app=${OP_NS}.cephfs.csi.ceph.com-ctrlplugin" \
+            -l "app=rook-ceph.cephfs.csi.ceph.com-ctrlplugin" \
             -o jsonpath='{.items[0].metadata.name}')
         POD_NS="$OP_NS"
         CONTAINER="csi-cephfsplugin"
@@ -300,6 +288,18 @@ runs:
         set -ex
         kubectl -n ${{ inputs.cluster-ns }} scale deployment rook-ceph-osd-0 --replicas 0
         kubectl rook-ceph ${NS_OPT} rook purge-osd 0 --force
+
+    - name: Mon restore
+      shell: bash --noprofile --norc -eo pipefail -x {0}
+      run: |
+        set -ex
+        # test the mon restore to restore to mon a, delete mons b and c, then add d and e
+        kubectl rook-ceph ${NS_OPT} mons restore-quorum a
+        kubectl -n ${{ inputs.cluster-ns }} wait pod -l app=rook-ceph-mon-b --for=delete --timeout=90s
+        kubectl -n ${{ inputs.cluster-ns }} wait pod -l app=rook-ceph-mon-c --for=delete --timeout=90s
+        tests/github-action-helper.sh wait_for_three_mons ${{ inputs.cluster-ns }}
+        kubectl -n ${{ inputs.cluster-ns }} wait deployment rook-ceph-mon-d --for condition=Available=True --timeout=90s
+        kubectl -n ${{ inputs.cluster-ns }} wait deployment rook-ceph-mon-e --for condition=Available=True --timeout=90s
 
     - name: Restore CRD without CRName
       shell: bash --noprofile --norc -eo pipefail -x {0}

--- a/tests/github-action-helper.sh
+++ b/tests/github-action-helper.sh
@@ -205,16 +205,10 @@ deploy_csi_drivers() {
 
     # Deploy RBD storage class
     download_and_modify_yaml "https://raw.githubusercontent.com/rook/rook/master/deploy/examples/csi/rbd/storageclass-test.yaml" "storageclass-rbd.yaml" "$operator_ns" "$cluster_ns"
-    if [[ "$operator_ns" != "$DEFAULT_OPERATOR_NS" ]]; then
-        sed -i "s|provisioner: rook-ceph.rbd.csi.ceph.com|provisioner: ${operator_ns}.rbd.csi.ceph.com|g" storageclass-rbd.yaml
-    fi
     apply_yaml "storageclass-rbd.yaml"
 
     # Deploy CephFS storage class
     download_and_modify_yaml "https://raw.githubusercontent.com/rook/rook/master/deploy/examples/csi/cephfs/storageclass.yaml" "storageclass-cephfs.yaml" "$operator_ns" "$cluster_ns"
-    if [[ "$operator_ns" != "$DEFAULT_OPERATOR_NS" ]]; then
-        sed -i "s|provisioner: rook-ceph.cephfs.csi.ceph.com|provisioner: ${operator_ns}.cephfs.csi.ceph.com|g" storageclass-cephfs.yaml
-    fi
     apply_yaml "storageclass-cephfs.yaml"
 
     wait_for_csi_drivers "$operator_ns"
@@ -295,9 +289,6 @@ create_sc_with_retain_policy() {
     download_and_modify_yaml "https://raw.githubusercontent.com/rook/rook/master/deploy/examples/csi/cephfs/storageclass.yaml" "storageclass-retain.yaml" "$operator_ns" "$cluster_ns"
     sed -i "s|name: rook-cephfs|name: rook-cephfs-retain|g" storageclass-retain.yaml
     sed -i "s|reclaimPolicy: Delete|reclaimPolicy: Retain|g" storageclass-retain.yaml
-    if [[ "$operator_ns" != "$DEFAULT_OPERATOR_NS" ]]; then
-        sed -i "s|provisioner: rook-ceph.cephfs.csi.ceph.com|provisioner: ${operator_ns}.cephfs.csi.ceph.com|g" storageclass-retain.yaml
-    fi
     apply_yaml "storageclass-retain.yaml"
 }
 
@@ -328,9 +319,6 @@ create_cephfs_snapshot() {
     download_and_modify_yaml "https://raw.githubusercontent.com/rook/rook/master/deploy/examples/csi/cephfs/snapshotclass.yaml" "snapshotclass-retain.yaml" "$operator_ns" "$cluster_ns"
     sed -i "s|name: csi-cephfsplugin-snapclass|name: csi-cephfsplugin-snapclass-retain|g" snapshotclass-retain.yaml
     sed -i "s|deletionPolicy: Delete|deletionPolicy: Retain|g" snapshotclass-retain.yaml
-    if [[ "$operator_ns" != "$DEFAULT_OPERATOR_NS" ]]; then
-        sed -i "s|driver: rook-ceph.cephfs.csi.ceph.com|driver: ${operator_ns}.cephfs.csi.ceph.com|g" snapshotclass-retain.yaml
-    fi
     apply_yaml "snapshotclass-retain.yaml"
 
     download_file "https://raw.githubusercontent.com/rook/rook/master/deploy/examples/csi/cephfs/pvc.yaml" "pvc-snap.yaml"
@@ -392,8 +380,7 @@ EOF
     # provisioner relies on the kubelet ConfigMap sync delay (~1-2 min)
     # plus external-provisioner exponential backoff (max 5 min), causing
     # PVC binding to stall for ~8 minutes in custom-namespace CI.
-    # The deployment name is "<operator_ns>.cephfs.csi.ceph.com-ctrlplugin".
-    local cephfs_deploy="${operator_ns}.cephfs.csi.ceph.com-ctrlplugin"
+    local cephfs_deploy="rook-ceph.cephfs.csi.ceph.com-ctrlplugin"
     kubectl rollout restart deployment "${cephfs_deploy}" -n "${operator_ns}"
     kubectl rollout status deployment "${cephfs_deploy}" \
         -n "${operator_ns}" --timeout=120s
@@ -417,10 +404,6 @@ EOF
         "storageclass-${svg}.yaml"
     sed -i "s|reclaimPolicy: Delete|reclaimPolicy: Retain|g" \
         "storageclass-${svg}.yaml"
-    if [[ "$operator_ns" != "$DEFAULT_OPERATOR_NS" ]]; then
-        sed -i "s|provisioner: rook-ceph.cephfs.csi.ceph.com|provisioner: ${operator_ns}.cephfs.csi.ceph.com|g" \
-            "storageclass-${svg}.yaml"
-    fi
     kubectl create -f "storageclass-${svg}.yaml"
 
     # 4. Create PVC to provision a subvolume in the SVG
@@ -538,8 +521,8 @@ wait_for_deployment_to_be_running() {
 # Wait for RBD and CephFS CSI controller plugins deployed by ceph-csi-operator.
 wait_for_csi_drivers() {
     local operator_ns="${1:-$DEFAULT_OPERATOR_NS}"
-    local rbd_deploy="${operator_ns}.rbd.csi.ceph.com-ctrlplugin"
-    local cephfs_deploy="${operator_ns}.cephfs.csi.ceph.com-ctrlplugin"
+    local rbd_deploy="rook-ceph.rbd.csi.ceph.com-ctrlplugin"
+    local cephfs_deploy="rook-ceph.cephfs.csi.ceph.com-ctrlplugin"
 
     wait_for_deployment_to_be_running "$rbd_deploy" "$operator_ns"
     wait_for_deployment_to_be_running "$cephfs_deploy" "$operator_ns"


### PR DESCRIPTION
with csi-operator managing the csi deployment
no need for different driver/pod names/label
based on different operator namespace. It is
rook-ceph only.

Also, moved the mon restore command to later in the
ci command list as sometime restore mon command take
longer time or ceph status takes time to be healthy.


<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
