### PR TITLE
core: Add Network MTU Config health check

### DIFF
--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -107,6 +107,15 @@ func Health(ctx context.Context, clientsets *k8sutil.Clientsets, operatorNamespa
 		}},
 	}
 
+	if isOpenShiftCluster(ctx, clientsets.Dynamic) {
+		checks = append(checks, struct {
+			name string
+			run  func() CheckResult
+		}{CheckNetworkMTUConfig, func() CheckResult {
+			return checkNetworkMTUConfig(ctx, clientsets.Dynamic)
+		}})
+	}
+
 	for _, c := range checks {
 		logging.Plain("Checking %s...", c.name)
 		results = append(results, c.run())

--- a/pkg/health/network.go
+++ b/pkg/health/network.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2026 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package health
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+)
+
+const mtuWarningThreshold = 8900
+
+func isOpenShiftCluster(ctx context.Context, dynamicClient dynamic.Interface) bool {
+	gvr := schema.GroupVersionResource{
+		Group:    "config.openshift.io",
+		Version:  "v1",
+		Resource: "networks",
+	}
+	_, err := dynamicClient.Resource(gvr).Get(ctx, "cluster", metav1.GetOptions{})
+	return err == nil
+}
+
+func checkNetworkMTUConfig(ctx context.Context, dynamicClient dynamic.Interface) CheckResult {
+	result := CheckResult{
+		Name:     CheckNetworkMTUConfig,
+		Category: CategoryNetwork,
+	}
+
+	osMTU, osNetType, osErr := getOpenShiftClusterMTU(ctx, dynamicClient)
+
+	if osErr == nil {
+		tag := "[INFO]"
+		if osMTU < mtuWarningThreshold {
+			tag = "[WARN]"
+		}
+		result.Details = append(result.Details, fmt.Sprintf("%s OpenShift cluster network MTU: %d (network type: %s)", tag, osMTU, osNetType))
+		result.Status, result.Message = evaluateClusterMTU(osMTU, mtuWarningThreshold)
+	} else {
+		result.Status = StatusOK
+		result.Message = fmt.Sprintf("MTU information not available via cluster APIs: %v", osErr)
+	}
+
+	return result
+}
+
+func getOpenShiftClusterMTU(ctx context.Context, dynamicClient dynamic.Interface) (int, string, error) {
+	gvr := schema.GroupVersionResource{
+		Group:    "config.openshift.io",
+		Version:  "v1",
+		Resource: "networks",
+	}
+
+	obj, err := dynamicClient.Resource(gvr).Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		return 0, "", err
+	}
+
+	mtu, _, err := unstructured.NestedInt64(obj.Object, "status", "clusterNetworkMTU")
+	if err != nil {
+		return 0, "", fmt.Errorf("failed to read clusterNetworkMTU: %v", err)
+	}
+	netType, _, err := unstructured.NestedString(obj.Object, "status", "networkType")
+	if err != nil {
+		return 0, "", fmt.Errorf("failed to read networkType: %v", err)
+	}
+
+	return int(mtu), netType, nil
+}
+
+func evaluateClusterMTU(mtu, threshold int) (CheckStatus, string) {
+	if mtu >= threshold {
+		return StatusOK, fmt.Sprintf("Cluster network MTU %d meets recommended threshold %d", mtu, threshold)
+	}
+	return StatusWarning, fmt.Sprintf("Cluster network MTU %d is below recommended threshold %d", mtu, threshold)
+}

--- a/pkg/health/network_test.go
+++ b/pkg/health/network_test.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2026 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package health
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+var osGVR = schema.GroupVersionResource{
+	Group: "config.openshift.io", Version: "v1", Resource: "networks",
+}
+
+func newDynamicClient(gvrs map[schema.GroupVersionResource]string) *dynamicfake.FakeDynamicClient {
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(), gvrs,
+	)
+}
+
+func createOpenShiftNetwork(t *testing.T, client *dynamicfake.FakeDynamicClient, mtu int64, networkType string) {
+	t.Helper()
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "config.openshift.io/v1",
+			"kind":       "Network",
+			"metadata":   map[string]interface{}{"name": "cluster"},
+			"status": map[string]interface{}{
+				"clusterNetworkMTU": mtu,
+				"networkType":       networkType,
+			},
+		},
+	}
+	_, err := client.Resource(osGVR).Create(context.Background(), obj, metav1.CreateOptions{})
+	require.NoError(t, err)
+}
+
+func TestEvaluateClusterMTU(t *testing.T) {
+	tests := []struct {
+		name       string
+		mtu        int
+		threshold  int
+		wantStatus CheckStatus
+		wantMsg    string
+	}{
+		{"above threshold", 9000, 8900, StatusOK, "meets recommended"},
+		{"at threshold", 8900, 8900, StatusOK, "meets recommended"},
+		{"below threshold", 1500, 8900, StatusWarning, "below recommended"},
+		{"just below", 8899, 8900, StatusWarning, "below recommended"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			status, msg := evaluateClusterMTU(tt.mtu, tt.threshold)
+			assert.Equal(t, tt.wantStatus, status)
+			assert.Contains(t, msg, tt.wantMsg)
+		})
+	}
+}
+
+func TestGetOpenShiftClusterMTU(t *testing.T) {
+	t.Run("OpenShift present", func(t *testing.T) {
+		client := newDynamicClient(map[schema.GroupVersionResource]string{osGVR: "NetworkList"})
+		createOpenShiftNetwork(t, client, 8901, "OVNKubernetes")
+
+		mtu, netType, err := getOpenShiftClusterMTU(context.Background(), client)
+		require.NoError(t, err)
+		assert.Equal(t, 8901, mtu)
+		assert.Equal(t, "OVNKubernetes", netType)
+	})
+
+	t.Run("non-OpenShift", func(t *testing.T) {
+		client := newDynamicClient(map[schema.GroupVersionResource]string{})
+		_, _, err := getOpenShiftClusterMTU(context.Background(), client)
+		assert.Error(t, err)
+	})
+}
+
+func TestCheckNetworkMTUConfigGoodMTU(t *testing.T) {
+	client := newDynamicClient(map[schema.GroupVersionResource]string{osGVR: "NetworkList"})
+	createOpenShiftNetwork(t, client, 8901, "OVNKubernetes")
+
+	result := checkNetworkMTUConfig(context.Background(), client)
+	assert.Equal(t, CheckNetworkMTUConfig, result.Name)
+	assert.Equal(t, CategoryNetwork, result.Category)
+	assert.Equal(t, StatusOK, result.Status)
+	assert.Contains(t, result.Message, "8901")
+
+	hasInfoMTU := false
+	for _, d := range result.Details {
+		if strings.Contains(d, "OpenShift cluster network MTU: 8901") {
+			assert.Contains(t, d, "[INFO]")
+			hasInfoMTU = true
+		}
+	}
+	assert.True(t, hasInfoMTU, "good MTU should be tagged [INFO]")
+}
+
+func TestCheckNetworkMTUConfigLowMTU(t *testing.T) {
+	client := newDynamicClient(map[schema.GroupVersionResource]string{osGVR: "NetworkList"})
+	createOpenShiftNetwork(t, client, 1500, "OVNKubernetes")
+
+	result := checkNetworkMTUConfig(context.Background(), client)
+	assert.Equal(t, StatusWarning, result.Status)
+	assert.Contains(t, result.Message, "below")
+
+	hasWarnMTU := false
+	for _, d := range result.Details {
+		if strings.Contains(d, "OpenShift cluster network MTU: 1500") {
+			assert.Contains(t, d, "[WARN]")
+			hasWarnMTU = true
+		}
+	}
+	assert.True(t, hasWarnMTU, "low MTU should be tagged [WARN]")
+}
+
+func TestCheckNetworkMTUConfigNonOpenShift(t *testing.T) {
+	client := newDynamicClient(map[schema.GroupVersionResource]string{})
+
+	result := checkNetworkMTUConfig(context.Background(), client)
+	assert.Equal(t, StatusOK, result.Status)
+	assert.Contains(t, result.Message, "not available")
+}

--- a/pkg/health/reporter.go
+++ b/pkg/health/reporter.go
@@ -121,12 +121,15 @@ func printCheckResult(r CheckResult, verbose bool) {
 	}
 
 	if verbose && len(r.Items) > 0 {
+		logging.Plain("\tItems:")
 		for _, item := range r.Items {
 			label := item.Name
 			if item.Namespace != "" {
 				label = path.Join(item.Namespace, item.Name)
 			}
-			if item.Node != "" {
+			if item.Details != "" {
+				logging.Plain("\t\t- %s: %s", label, item.Details)
+			} else if item.Node != "" {
 				logging.Plain("\t\t- %s -> %s (%s)", label, item.Node, item.Status)
 			} else {
 				logging.Plain("\t\t- %s (%s)", label, item.Status)

--- a/pkg/health/reporter_test.go
+++ b/pkg/health/reporter_test.go
@@ -346,6 +346,7 @@ func TestPrintCheckResultVerboseTrueShowsItems(t *testing.T) {
 		printCheckResult(result, true)
 	})
 
+	assert.Contains(t, output, "Items:")
 	assert.Contains(t, output, "mon-a -> node1 (Running)")
 }
 
@@ -534,4 +535,43 @@ func TestFormatReportTextFallback(t *testing.T) {
 	})
 
 	assert.Contains(t, stderr, "CLUSTER HEALTH REPORT")
+}
+
+func TestPrintCheckResultItemWithDetails(t *testing.T) {
+	result := CheckResult{
+		Name:    "Network MTU Config",
+		Status:  StatusOK,
+		Message: "Network MTU 9000 consistent",
+		Items: []CheckItem{
+			{Name: "default/public-net", Details: "role=public, MTU 9000"},
+			{Name: "default/private-net", Details: "role=cluster, MTU not specified, inherits from host NIC ens224"},
+		},
+	}
+
+	output := captureOutput(t, func() {
+		printCheckResult(result, true)
+	})
+
+	assert.Contains(t, output, "Items:")
+	assert.Contains(t, output, "default/public-net: role=public, MTU 9000")
+	assert.Contains(t, output, "default/private-net: role=cluster, MTU not specified, inherits from host NIC ens224")
+}
+
+func TestPrintCheckResultItemWithDetailsHiddenInNonVerbose(t *testing.T) {
+	result := CheckResult{
+		Name:    "Network MTU Config",
+		Status:  StatusOK,
+		Message: "Network MTU 9000 consistent",
+		Items: []CheckItem{
+			{Name: "default/public-net", Details: "role=public, MTU 9000"},
+		},
+	}
+
+	output := captureOutput(t, func() {
+		printCheckResult(result, false)
+	})
+
+	assert.Contains(t, output, "Network MTU Config")
+	assert.NotContains(t, output, "Items:")
+	assert.NotContains(t, output, "default/public-net")
 }

--- a/pkg/health/types.go
+++ b/pkg/health/types.go
@@ -94,6 +94,7 @@ const (
 	CheckMGRStatus            = "MGR Status"
 	CheckNodeResourcePressure = "Node Resource Pressure"
 	CheckClusterCapacity      = "Cluster Capacity"
+	CheckNetworkMTUConfig     = "Network MTU Config"
 )
 
 // CheckResult represents the outcome of a single health check.


### PR DESCRIPTION
Adds a new health check that validates network MTU configuration for Ceph clusters. Ceph recommends
jumbo frames (MTU >= 9000) for OSD replication
traffic,and undersized MTU silently degrades
throughput.

MTU Sources
The check collects MTU from the following resources:
- OpenShift Network (config.openshift.io/v1/networks/cluster) — reads status.clusterNetworkMTU and status.networkType from the cluster-scoped singleton
```
./bin/kubectl-rook-ceph -n openshift-storage health 
Checking Ceph status...
Checking Mon Distribution...
Checking Ceph Cluster Health...
Checking OSD Distribution...
Checking Pods Status...
Checking PG Status...
Checking MGR Status...
Checking Network MTU Config...

========================================================================
CLUSTER HEALTH REPORT
========================================================================
Generated: 2026-07-27 12:55:23 UTC
Namespace: openshift-storage

========================================================================
Storage
========================================================================

[OK] Ceph Cluster Health [OK]
	Status: HEALTH_OK

[OK] PG Status [OK]
	Status: 169 PGs in healthy state
	Details:
		- PgState: active+clean, PgCount: 169

========================================================================
K8s Resources
========================================================================

[OK] Mon Distribution [OK]
	Status: 3 mon pods running on 3 different nodes
	Details:
		- 3/3 mons in quorum

[OK] OSD Distribution [OK]
	Status: 3 osd pods running on 3 different nodes

[OK] Pods Status [OK]
	Status: All 43 pods are Running/Succeeded
	Details:
		- 43 Running/Succeeded across checked namespaces

[OK] MGR Status [OK]
	Status: 2 mgr pod(s) running

========================================================================
Network
========================================================================

[!!] Network MTU Config [WARNING]
	Status: Cluster network MTU 1400 is below recommended threshold 8900
	Details:
		- [WARN] OpenShift cluster network MTU: 1400 (network type: OVNKubernetes)

========================================================================
SUMMARY
========================================================================
Total Checks: 7
OK:           6
Warning:      1
```
```
./bin/kubectl-rook-ceph -n openshift-storage health --verbose
Checking Ceph status...
Checking Mon Distribution...
Checking Ceph Cluster Health...
Checking OSD Distribution...
Checking Pods Status...
Checking PG Status...
Checking MGR Status...
Checking Network MTU Config...

========================================================================
CLUSTER HEALTH REPORT
========================================================================
Generated: 2026-07-24 09:10:35 UTC
Namespace: openshift-storage

========================================================================
Storage
========================================================================

[OK] Ceph Cluster Health [OK]
	Status: HEALTH_OK

[OK] PG Status [OK]
	Status: 200 PGs in healthy state
	Details:
		- PgState: active+clean, PgCount: 200

========================================================================
K8s Resources
========================================================================

[OK] Mon Distribution [OK]
	Status: 3 mon pods running on 3 different nodes
	Details:
		- 3/3 mons in quorum
	Items:
		- rook-ceph-mon-a-574ccf8dbd-rxhbb -> compute-2 (Running)
		- rook-ceph-mon-b-55bf7bd758-9rw7h -> compute-1 (Running)
		- rook-ceph-mon-c-59b7b955f8-h2npb -> compute-0 (Running)

[OK] OSD Distribution [OK]
	Status: 3 osd pods running on 3 different nodes
	Items:
		- rook-ceph-osd-0-6cd448cdf8-w9qzl -> compute-0 (Running)
		- rook-ceph-osd-1-6d678c897c-jwdtp -> compute-2 (Running)
		- rook-ceph-osd-2-869d4d5db9-ttvjd -> compute-1 (Running)

[OK] Pods Status [OK]
	Status: All 58 pods are Running/Succeeded
	Details:
		- 58 Running/Succeeded across checked namespaces

[OK] MGR Status [OK]
	Status: 2 mgr pod(s) running
	Items:
		- rook-ceph-mgr-a-7554d5698d-fdxvj -> compute-2 (Running)
		- rook-ceph-mgr-b-7f787bdfd8-28bz6 -> compute-0 (Running)

========================================================================
Network
========================================================================

[!!] Network MTU Config [WARNING]
	Status: 1 MTU source(s) below 9000
	Details:
		- [WARN] OpenShift cluster network MTU: 1400 (network type: OVNKubernetes)
             
========================================================================
SUMMARY
========================================================================
Total Checks: 7
OK:           6
Warning:      1
```