### PR TITLE
core: print health command in json/yaml format

### DIFF
--- a/cmd/commands/health.go
+++ b/cmd/commands/health.go
@@ -21,7 +21,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var healthVerbose bool
+var (
+	healthVerbose bool
+	healthOutput  string
+)
 
 var Health = &cobra.Command{
 	Use:   "health",
@@ -31,10 +34,11 @@ var Health = &cobra.Command{
 		verifyOperatorPodIsRunning(cmd.Context(), clientSets)
 	},
 	Run: func(cmd *cobra.Command, _ []string) {
-		health.Health(cmd.Context(), clientSets, operatorNamespace, cephClusterNamespace, healthVerbose, "")
+		health.Health(cmd.Context(), clientSets, operatorNamespace, cephClusterNamespace, healthVerbose, "", healthOutput)
 	},
 }
 
 func init() {
 	Health.Flags().BoolVar(&healthVerbose, "verbose", false, "shows detailed check for pods")
+	Health.Flags().StringVarP(&healthOutput, "output", "o", "text", "output format: text, json, yaml")
 }

--- a/docs/health.md
+++ b/docs/health.md
@@ -32,9 +32,18 @@ Any other PG state is flagged as a warning or critical issue.
 ```bash
 kubectl rook-ceph health
 kubectl rook-ceph health --verbose
+kubectl rook-ceph health -o json
+kubectl rook-ceph health -o yaml
 ```
 
 Use `--verbose` to include individual resource details (e.g., pod names, nodes) for each check.
+
+Use `-o`/`--output` to change the output format. Supported values: `text` (default), `json`, `yaml`. JSON and YAML output is printed to stdout so it can be captured separately from progress logs (which go to stderr):
+
+```bash
+kubectl rook-ceph health -o json > report.json
+kubectl rook-ceph health -o json 2>/dev/null | jq .
+```
 
 ## Example Output
 

--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -61,7 +61,7 @@ type PgStateEntry struct {
 	Count     int    `json:"count"`
 }
 
-func Health(ctx context.Context, clientsets *k8sutil.Clientsets, operatorNamespace, clusterNamespace string, verbose bool, nodeSelector string) {
+func Health(ctx context.Context, clientsets *k8sutil.Clientsets, operatorNamespace, clusterNamespace string, verbose bool, nodeSelector, outputFormat string) {
 	var results []CheckResult
 
 	logging.Plain("Checking Ceph status...")
@@ -99,7 +99,7 @@ func Health(ctx context.Context, clientsets *k8sutil.Clientsets, operatorNamespa
 		results = append(results, c.run())
 	}
 
-	printReport(clusterNamespace, results, verbose)
+	formatReport(clusterNamespace, results, outputFormat, verbose)
 }
 
 func checkMonDistribution(ctx context.Context, k8sclientset kubernetes.Interface, clusterNamespace string, status cephStatus, statusErr error) CheckResult {

--- a/pkg/health/reporter.go
+++ b/pkg/health/reporter.go
@@ -18,7 +18,9 @@ package health
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
+	"os"
 	"path"
 	"sort"
 	"strings"
@@ -27,6 +29,7 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/rook/kubectl-rook-ceph/pkg/logging"
+	"gopkg.in/yaml.v3"
 )
 
 var categoryOrder = []string{CategoryStorage, CategoryK8sResources, CategoryNetwork, CategoryObjectStorage}
@@ -226,4 +229,41 @@ func groupByCategory(results []CheckResult) map[string][]CheckResult {
 		grouped[r.Category] = append(grouped[r.Category], r)
 	}
 	return grouped
+}
+
+func formatReport(clusterNamespace string, results []CheckResult, format string, verbose bool) {
+	switch format {
+	case "json":
+		report := buildReport(clusterNamespace, results)
+		data, err := json.MarshalIndent(report, "", "  ")
+		if err != nil {
+			logging.Fatal(fmt.Errorf("failed to marshal JSON report: %v", err))
+		}
+		fmt.Fprintln(os.Stdout, string(data))
+	case "yaml":
+		report := buildReport(clusterNamespace, results)
+		data, err := yaml.Marshal(report)
+		if err != nil {
+			logging.Fatal(fmt.Errorf("failed to marshal YAML report: %v", err))
+		}
+		fmt.Fprint(os.Stdout, string(data))
+	default:
+		printReport(clusterNamespace, results, verbose)
+	}
+}
+
+func buildReport(clusterNamespace string, results []CheckResult) HealthReport {
+	ok, warning, critical, errCount := countByStatus(results)
+	return HealthReport{
+		Namespace: clusterNamespace,
+		Timestamp: time.Now().UTC(),
+		Checks:    results,
+		Summary: ReportSummary{
+			Total:    len(results),
+			OK:       ok,
+			Warning:  warning,
+			Critical: critical,
+			Error:    errCount,
+		},
+	}
 }

--- a/pkg/health/reporter_test.go
+++ b/pkg/health/reporter_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package health
 
 import (
+	"encoding/json"
 	"io"
 	"os"
 	"strings"
@@ -24,6 +25,8 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 // captureOutput redirects os.Stderr to a pipe, runs fn, and returns what was printed.
@@ -344,4 +347,191 @@ func TestPrintCheckResultVerboseTrueShowsItems(t *testing.T) {
 	})
 
 	assert.Contains(t, output, "mon-a -> node1 (Running)")
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+	os.Stdout = w
+
+	var out []byte
+	done := make(chan struct{})
+	go func() {
+		out, _ = io.ReadAll(r)
+		close(done)
+	}()
+
+	fn()
+	_ = w.Close()
+	<-done
+	_ = r.Close()
+	os.Stdout = old
+
+	return string(out)
+}
+
+func TestCheckStatusMarshalJSON(t *testing.T) {
+	tests := []struct {
+		status   CheckStatus
+		expected string
+	}{
+		{StatusOK, `"ok"`},
+		{StatusWarning, `"warning"`},
+		{StatusCritical, `"critical"`},
+		{StatusError, `"error"`},
+	}
+	for _, tt := range tests {
+		data, err := json.Marshal(tt.status)
+		require.NoError(t, err)
+		assert.Equal(t, tt.expected, string(data))
+	}
+}
+
+func TestCheckStatusUnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected CheckStatus
+	}{
+		{`"ok"`, StatusOK},
+		{`"warning"`, StatusWarning},
+		{`"critical"`, StatusCritical},
+		{`"error"`, StatusError},
+	}
+	for _, tt := range tests {
+		var s CheckStatus
+		err := json.Unmarshal([]byte(tt.input), &s)
+		require.NoError(t, err)
+		assert.Equal(t, tt.expected, s)
+	}
+}
+
+func TestCheckStatusUnmarshalJSONInvalid(t *testing.T) {
+	var s CheckStatus
+	err := json.Unmarshal([]byte(`"bogus"`), &s)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown status")
+}
+
+func TestFormatReportJSON(t *testing.T) {
+	results := []CheckResult{
+		{
+			Name:     "Ceph Cluster Health",
+			Category: "Storage",
+			Status:   StatusOK,
+			Message:  "HEALTH_OK",
+		},
+		{
+			Name:     "Mon Distribution",
+			Category: "K8s Resources",
+			Status:   StatusWarning,
+			Message:  "2 mons on 2 nodes",
+			Details:  []string{"2/3 mons in quorum"},
+			Items: []CheckItem{
+				{Name: "mon-a", Status: "Running", Node: "node1"},
+				{Name: "mon-b", Status: "Running", Node: "node2"},
+			},
+		},
+	}
+
+	stdout := captureStdout(t, func() {
+		formatReport("rook-ceph", results, "json", false)
+	})
+
+	var report HealthReport
+	err := json.Unmarshal([]byte(stdout), &report)
+	require.NoError(t, err)
+
+	assert.Equal(t, "rook-ceph", report.Namespace)
+	assert.False(t, report.Timestamp.IsZero())
+	require.Len(t, report.Checks, 2)
+
+	assert.Equal(t, "Ceph Cluster Health", report.Checks[0].Name)
+	assert.Equal(t, StatusOK, report.Checks[0].Status)
+	assert.Empty(t, report.Checks[0].Details)
+
+	assert.Equal(t, "Mon Distribution", report.Checks[1].Name)
+	assert.Equal(t, StatusWarning, report.Checks[1].Status)
+	assert.Equal(t, []string{"2/3 mons in quorum"}, report.Checks[1].Details)
+	require.Len(t, report.Checks[1].Items, 2)
+	assert.Equal(t, "mon-a", report.Checks[1].Items[0].Name)
+	assert.Equal(t, "node1", report.Checks[1].Items[0].Node)
+
+	assert.Equal(t, 2, report.Summary.Total)
+	assert.Equal(t, 1, report.Summary.OK)
+	assert.Equal(t, 1, report.Summary.Warning)
+	assert.Equal(t, 0, report.Summary.Critical)
+	assert.Equal(t, 0, report.Summary.Error)
+}
+
+func TestFormatReportJSONStatusAsString(t *testing.T) {
+	results := []CheckResult{
+		{Name: "Test", Category: "Storage", Status: StatusWarning, Message: "warn"},
+	}
+
+	stdout := captureStdout(t, func() {
+		formatReport("ns", results, "json", false)
+	})
+
+	assert.Contains(t, stdout, `"status": "warning"`)
+	assert.NotContains(t, stdout, `"status": 1`)
+}
+
+func TestFormatReportJSONOmitsEmptyFields(t *testing.T) {
+	results := []CheckResult{
+		{Name: "Test", Category: "Storage", Status: StatusOK, Message: "ok"},
+	}
+
+	stdout := captureStdout(t, func() {
+		formatReport("ns", results, "json", false)
+	})
+
+	assert.NotContains(t, stdout, `"details"`)
+	assert.NotContains(t, stdout, `"items"`)
+}
+
+func TestFormatReportYAML(t *testing.T) {
+	results := []CheckResult{
+		{
+			Name:     "PG Status",
+			Category: "Storage",
+			Status:   StatusOK,
+			Message:  "128 PGs healthy",
+			Details:  []string{"active+clean: 128"},
+		},
+	}
+
+	stdout := captureStdout(t, func() {
+		formatReport("rook-ceph", results, "yaml", false)
+	})
+
+	var report HealthReport
+	err := yaml.Unmarshal([]byte(stdout), &report)
+	require.NoError(t, err)
+
+	assert.Equal(t, "rook-ceph", report.Namespace)
+	require.Len(t, report.Checks, 1)
+	assert.Equal(t, "PG Status", report.Checks[0].Name)
+	assert.Equal(t, StatusOK, report.Checks[0].Status)
+	assert.Equal(t, 1, report.Summary.Total)
+	assert.Equal(t, 1, report.Summary.OK)
+}
+
+func TestFormatReportTextFallback(t *testing.T) {
+	results := []CheckResult{
+		{Name: "Test", Category: "Storage", Status: StatusOK, Message: "ok"},
+	}
+
+	stderr := captureOutput(t, func() {
+		stdout := captureStdout(t, func() {
+			formatReport("ns", results, "text", false)
+		})
+		assert.Empty(t, stdout)
+	})
+
+	assert.Contains(t, stderr, "CLUSTER HEALTH REPORT")
 }

--- a/pkg/health/types.go
+++ b/pkg/health/types.go
@@ -16,6 +16,14 @@ limitations under the License.
 
 package health
 
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
 // CheckStatus represents the severity level of a health check result.
 type CheckStatus int
 
@@ -25,6 +33,52 @@ const (
 	StatusCritical
 	StatusError
 )
+
+var statusStrings = map[CheckStatus]string{
+	StatusOK:       "ok",
+	StatusWarning:  "warning",
+	StatusCritical: "critical",
+	StatusError:    "error",
+}
+
+func (s CheckStatus) String() string {
+	if str, ok := statusStrings[s]; ok {
+		return str
+	}
+	return "error"
+}
+
+func (s CheckStatus) MarshalJSON() ([]byte, error) {
+	return json.Marshal(s.String())
+}
+
+func (s *CheckStatus) UnmarshalJSON(data []byte) error {
+	var str string
+	if err := json.Unmarshal(data, &str); err != nil {
+		return err
+	}
+	for k, v := range statusStrings {
+		if v == str {
+			*s = k
+			return nil
+		}
+	}
+	return fmt.Errorf("unknown status: %q", str)
+}
+
+func (s CheckStatus) MarshalYAML() (interface{}, error) {
+	return s.String(), nil
+}
+
+func (s *CheckStatus) UnmarshalYAML(value *yaml.Node) error {
+	for k, v := range statusStrings {
+		if v == value.Value {
+			*s = k
+			return nil
+		}
+	}
+	return fmt.Errorf("unknown status: %q", value.Value)
+}
 
 const (
 	CategoryStorage       = "Storage"
@@ -43,19 +97,36 @@ const (
 
 // CheckResult represents the outcome of a single health check.
 type CheckResult struct {
-	Name     string
-	Category string
-	Status   CheckStatus
-	Message  string
-	Details  []string
-	Items    []CheckItem
+	Name     string      `json:"name" yaml:"name"`
+	Category string      `json:"category" yaml:"category"`
+	Status   CheckStatus `json:"status" yaml:"status"`
+	Message  string      `json:"message" yaml:"message"`
+	Details  []string    `json:"details,omitempty" yaml:"details,omitempty"`
+	Items    []CheckItem `json:"items,omitempty" yaml:"items,omitempty"`
 }
 
 // CheckItem represents an individual resource within a check.
 type CheckItem struct {
-	Name      string
-	Namespace string
-	Status    string
-	Node      string
-	Details   string
+	Name      string `json:"name" yaml:"name"`
+	Namespace string `json:"namespace,omitempty" yaml:"namespace,omitempty"`
+	Status    string `json:"status,omitempty" yaml:"status,omitempty"`
+	Node      string `json:"node,omitempty" yaml:"node,omitempty"`
+	Details   string `json:"details,omitempty" yaml:"details,omitempty"`
+}
+
+// HealthReport is the top-level structure for JSON/YAML output.
+type HealthReport struct {
+	Namespace string        `json:"namespace" yaml:"namespace"`
+	Timestamp time.Time     `json:"timestamp" yaml:"timestamp"`
+	Checks    []CheckResult `json:"checks" yaml:"checks"`
+	Summary   ReportSummary `json:"summary" yaml:"summary"`
+}
+
+// ReportSummary counts check results by status.
+type ReportSummary struct {
+	Total    int `json:"total" yaml:"total"`
+	OK       int `json:"ok" yaml:"ok"`
+	Warning  int `json:"warning" yaml:"warning"`
+	Critical int `json:"critical" yaml:"critical"`
+	Error    int `json:"error" yaml:"error"`
 }


### PR DESCRIPTION
this commit adds another flag output to the
health command which will allow the user to
view the health report in either yaml or
json format

```
./bin/kubectl-rook-ceph -n openshift-storage health -o json
Checking Ceph status...
Checking Mon Distribution...
Checking Ceph Cluster Health...
Checking OSD Distribution...
Checking Pods Status...
Checking PG Status...
Checking MGR Status...
{
  "namespace": "openshift-storage",
  "timestamp": "2026-07-24T15:25:42.0405939Z",
  "checks": [
    {
      "name": "Mon Distribution",
      "category": "K8s Resources",
      "status": "ok",
      "message": "3 mon pods running on 3 different nodes",
      "details": [
        "3/3 mons in quorum"
      ],
      "items": [
        {
          "name": "rook-ceph-mon-a-574ccf8dbd-rxhbb",
          "status": "Running",
          "node": "compute-2"
        },
        {
          "name": "rook-ceph-mon-b-55bf7bd758-9rw7h",
          "status": "Running",
          "node": "compute-1"
        },
        {
          "name": "rook-ceph-mon-c-59b7b955f8-h2npb",
          "status": "Running",
          "node": "compute-0"
        }
      ]
    },
    {
      "name": "Ceph Cluster Health",
      "category": "Storage",
      "status": "ok",
      "message": "HEALTH_OK"
    },
    {
      "name": "OSD Distribution",
      "category": "K8s Resources",
      "status": "ok",
      "message": "3 osd pods running on 3 different nodes",
      "items": [
        {
          "name": "rook-ceph-osd-0-6cd448cdf8-w9qzl",
          "status": "Running",
          "node": "compute-0"
        },
        {
          "name": "rook-ceph-osd-1-6d678c897c-jwdtp",
          "status": "Running",
          "node": "compute-2"
        },
        {
          "name": "rook-ceph-osd-2-869d4d5db9-ttvjd",
          "status": "Running",
          "node": "compute-1"
        }
      ]
    },
    {
      "name": "Pods Status",
      "category": "K8s Resources",
      "status": "ok",
      "message": "All 58 pods are Running/Succeeded",
      "details": [
        "58 Running/Succeeded across checked namespaces"
      ]
    },
    {
      "name": "PG Status",
      "category": "Storage",
      "status": "ok",
      "message": "200 PGs in healthy state",
      "details": [
        "PgState: active+clean, PgCount: 200"
      ]
    },
    {
      "name": "MGR Status",
      "category": "K8s Resources",
      "status": "ok",
      "message": "2 mgr pod(s) running",
      "items": [
        {
          "name": "rook-ceph-mgr-a-7554d5698d-fdxvj",
          "status": "Running",
          "node": "compute-2"
        },
        {
          "name": "rook-ceph-mgr-b-7f787bdfd8-28bz6",
          "status": "Running",
          "node": "compute-0"
        }
      ]
    }
  ],
  "summary": {
    "total": 6,
    "ok": 6,
    "warning": 0,
    "critical": 0,
    "error": 0
  }
}
ypadia:kubectl-rook-ceph$ ./bin/kubectl-rook-ceph -n openshift-storage health -o yaml
Checking Ceph status...
Checking Mon Distribution...
Checking Ceph Cluster Health...
Checking OSD Distribution...
Checking Pods Status...
Checking PG Status...
Checking MGR Status...
namespace: openshift-storage
timestamp: 2026-07-24T15:26:07.829246495Z
checks:
    - name: Mon Distribution
      category: K8s Resources
      status: ok
      message: 3 mon pods running on 3 different nodes
      details:
        - 3/3 mons in quorum
      items:
        - name: rook-ceph-mon-a-574ccf8dbd-rxhbb
          status: Running
          node: compute-2
        - name: rook-ceph-mon-b-55bf7bd758-9rw7h
          status: Running
          node: compute-1
        - name: rook-ceph-mon-c-59b7b955f8-h2npb
          status: Running
          node: compute-0
    - name: Ceph Cluster Health
      category: Storage
      status: ok
      message: HEALTH_OK
    - name: OSD Distribution
      category: K8s Resources
      status: ok
      message: 3 osd pods running on 3 different nodes
      items:
        - name: rook-ceph-osd-0-6cd448cdf8-w9qzl
          status: Running
          node: compute-0
        - name: rook-ceph-osd-1-6d678c897c-jwdtp
          status: Running
          node: compute-2
        - name: rook-ceph-osd-2-869d4d5db9-ttvjd
          status: Running
          node: compute-1
    - name: Pods Status
      category: K8s Resources
      status: ok
      message: All 58 pods are Running/Succeeded
      details:
        - 58 Running/Succeeded across checked namespaces
    - name: PG Status
      category: Storage
      status: ok
      message: 200 PGs in healthy state
      details:
        - 'PgState: active+clean, PgCount: 200'
    - name: MGR Status
      category: K8s Resources
      status: ok
      message: 2 mgr pod(s) running
      items:
        - name: rook-ceph-mgr-a-7554d5698d-fdxvj
          status: Running
          node: compute-2
        - name: rook-ceph-mgr-b-7f787bdfd8-28bz6
          status: Running
          node: compute-0
summary:
    total: 6
    ok: 6
    warning: 0
    critical: 0
    error: 0
```
