### PR TITLE
core: add cluster capacity health check

### DIFF
--- a/pkg/health/capacity.go
+++ b/pkg/health/capacity.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2026 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package health
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/rook/kubectl-rook-ceph/pkg/exec"
+	"github.com/rook/kubectl-rook-ceph/pkg/k8sutil"
+)
+
+type cephDf struct {
+	Stats cephDfStats  `json:"stats"`
+	Pools []cephDfPool `json:"pools"`
+}
+
+type cephDfStats struct {
+	TotalBytes        int64   `json:"total_bytes"`
+	TotalUsedRawBytes int64   `json:"total_used_raw_bytes"`
+	TotalAvailBytes   int64   `json:"total_avail_bytes"`
+	TotalUsedRawRatio float64 `json:"total_used_raw_ratio"`
+}
+
+type cephDfPool struct {
+	Name  string          `json:"name"`
+	ID    int             `json:"id"`
+	Stats cephDfPoolStats `json:"stats"`
+}
+
+type cephDfPoolStats struct {
+	PercentUsed float64 `json:"percent_used"`
+	MaxAvail    int64   `json:"max_avail"`
+	Stored      int64   `json:"stored"`
+}
+
+// capacityHealthChecks lists ceph health check codes related to cluster capacity.
+// The bool value indicates membership in the set; true means the code is capacity-related
+// and the capacity check status should reflect its severity.
+var capacityHealthChecks = map[string]bool{
+	"NEARFULL_OSD":      true,
+	"BACKFILLFULL":      true,
+	"FULL_OSD":          true,
+	"POOL_NEARFULL":     true,
+	"POOL_BACKFILLFULL": true,
+	"POOL_FULL":         true,
+}
+
+func checkClusterCapacity(ctx context.Context, clientsets *k8sutil.Clientsets, operatorNamespace, clusterNamespace string, status cephStatus, statusErr error) CheckResult {
+	result := CheckResult{
+		Name:     CheckClusterCapacity,
+		Category: CategoryStorage,
+	}
+
+	dfOut, err := exec.RunCommandInOperatorPod(ctx, clientsets, "ceph", []string{"df", "--format", "json"}, operatorNamespace, clusterNamespace, true)
+	if err != nil {
+		result.Status = StatusError
+		result.Message = fmt.Sprintf("Failed to get ceph df: %v", err)
+		return result
+	}
+
+	var df cephDf
+	if err := json.Unmarshal([]byte(dfOut), &df); err != nil {
+		result.Status = StatusError
+		result.Message = fmt.Sprintf("Failed to parse ceph df output: %v", err)
+		return result
+	}
+
+	pct := df.Stats.TotalUsedRawRatio * 100
+	result.Status = StatusOK
+	result.Message = fmt.Sprintf("Cluster capacity %.1f%% used (%s / %s)",
+		pct, humanizeBytes(df.Stats.TotalUsedRawBytes), humanizeBytes(df.Stats.TotalBytes))
+
+	if statusErr == nil {
+		result.Status = capacityStatusFromHealth(status.Health.Checks)
+	}
+
+	for _, pool := range df.Pools {
+		poolPct := pool.Stats.PercentUsed * 100
+		result.Items = append(result.Items, CheckItem{
+			Name:    pool.Name,
+			Details: fmt.Sprintf("%.1f%% used, %s stored", poolPct, humanizeBytes(pool.Stats.Stored)),
+		})
+	}
+
+	return result
+}
+
+func capacityStatusFromHealth(checks map[string]healthCheckEntry) CheckStatus {
+	status := StatusOK
+	for code, check := range checks {
+		if !capacityHealthChecks[code] {
+			continue
+		}
+		if check.Severity == "HEALTH_ERR" {
+			return StatusCritical
+		}
+		status = StatusWarning
+	}
+	return status
+}
+
+func humanizeBytes(b int64) string {
+	const (
+		kib = 1024
+		mib = 1024 * kib
+		gib = 1024 * mib
+		tib = 1024 * gib
+	)
+
+	switch {
+	case b >= tib:
+		return fmt.Sprintf("%.1f TiB", float64(b)/float64(tib))
+	case b >= gib:
+		return fmt.Sprintf("%.1f GiB", float64(b)/float64(gib))
+	case b >= mib:
+		return fmt.Sprintf("%.1f MiB", float64(b)/float64(mib))
+	case b >= kib:
+		return fmt.Sprintf("%.1f KiB", float64(b)/float64(kib))
+	default:
+		return fmt.Sprintf("%d B", b)
+	}
+}

--- a/pkg/health/capacity_test.go
+++ b/pkg/health/capacity_test.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2026 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package health
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHumanizeBytes(t *testing.T) {
+	tests := []struct {
+		name     string
+		bytes    int64
+		expected string
+	}{
+		{"zero", 0, "0 B"},
+		{"bytes", 512, "512 B"},
+		{"kibibytes", 1536, "1.5 KiB"},
+		{"mebibytes", 10 * 1024 * 1024, "10.0 MiB"},
+		{"gibibytes", 3 * 1024 * 1024 * 1024, "3.0 GiB"},
+		{"tebibytes", 2 * 1024 * 1024 * 1024 * 1024, "2.0 TiB"},
+		{"large tebibytes", 15 * 1024 * 1024 * 1024 * 1024, "15.0 TiB"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, humanizeBytes(tt.bytes))
+		})
+	}
+}
+
+func TestParseCephDf(t *testing.T) {
+	rawJSON := `{
+		"stats": {
+			"total_bytes": 1099511627776,
+			"total_used_raw_bytes": 549755813888,
+			"total_avail_bytes": 549755813888,
+			"total_used_raw_ratio": 0.5
+		},
+		"pools": [
+			{
+				"name": "replicapool",
+				"id": 1,
+				"stats": {
+					"percent_used": 0.45,
+					"max_avail": 300000000000,
+					"stored": 200000000000
+				}
+			},
+			{
+				"name": ".mgr",
+				"id": 2,
+				"stats": {
+					"percent_used": 0.01,
+					"max_avail": 500000000000,
+					"stored": 5000000
+				}
+			}
+		]
+	}`
+
+	var df cephDf
+	err := json.Unmarshal([]byte(rawJSON), &df)
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(1099511627776), df.Stats.TotalBytes)
+	assert.InDelta(t, 0.5, df.Stats.TotalUsedRawRatio, 0.001)
+	assert.Len(t, df.Pools, 2)
+	assert.Equal(t, "replicapool", df.Pools[0].Name)
+	assert.InDelta(t, 0.45, df.Pools[0].Stats.PercentUsed, 0.001)
+}
+
+func TestCapacityStatusFromHealth(t *testing.T) {
+	tests := []struct {
+		name     string
+		checks   map[string]healthCheckEntry
+		expected CheckStatus
+	}{
+		{
+			"no checks",
+			nil,
+			StatusOK,
+		},
+		{
+			"unrelated warning",
+			map[string]healthCheckEntry{
+				"TOO_FEW_OSDS": {Severity: "HEALTH_WARN"},
+			},
+			StatusOK,
+		},
+		{
+			"nearfull warning",
+			map[string]healthCheckEntry{
+				"NEARFULL_OSD": {Severity: "HEALTH_WARN"},
+			},
+			StatusWarning,
+		},
+		{
+			"full error",
+			map[string]healthCheckEntry{
+				"FULL_OSD": {Severity: "HEALTH_ERR"},
+			},
+			StatusCritical,
+		},
+		{
+			"mixed nearfull and full",
+			map[string]healthCheckEntry{
+				"NEARFULL_OSD": {Severity: "HEALTH_WARN"},
+				"POOL_FULL":    {Severity: "HEALTH_ERR"},
+			},
+			StatusCritical,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, capacityStatusFromHealth(tt.checks))
+		})
+	}
+}

--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -49,7 +49,17 @@ type monEntry struct {
 }
 
 type healthStatus struct {
-	Status string `json:"status"`
+	Status string                      `json:"status"`
+	Checks map[string]healthCheckEntry `json:"checks"`
+}
+
+type healthCheckEntry struct {
+	Severity string             `json:"severity"`
+	Summary  healthCheckSummary `json:"summary"`
+}
+
+type healthCheckSummary struct {
+	Message string `json:"message"`
 }
 
 type pgMap struct {
@@ -91,6 +101,9 @@ func Health(ctx context.Context, clientsets *k8sutil.Clientsets, operatorNamespa
 		}},
 		{CheckNodeResourcePressure, func() CheckResult {
 			return checkNodeResourcePressure(ctx, clientsets.Kube, nodeSelector)
+		}},
+		{CheckClusterCapacity, func() CheckResult {
+			return checkClusterCapacity(ctx, clientsets, operatorNamespace, clusterNamespace, cephStatus, cephStatusErr)
 		}},
 	}
 
@@ -201,6 +214,14 @@ func checkCephClusterHealth(status cephStatus, statusErr error) CheckResult {
 	default:
 		result.Status = StatusError
 		result.Message = fmt.Sprintf("Unexpected health status: %s", status.Health.Status)
+	}
+
+	for code, check := range status.Health.Checks {
+		tag := "[WARN]"
+		if check.Severity == "HEALTH_ERR" {
+			tag = "[ERR]"
+		}
+		result.Details = append(result.Details, fmt.Sprintf("%s %s: %s", tag, code, check.Summary.Message))
 	}
 
 	return result

--- a/pkg/health/health_test.go
+++ b/pkg/health/health_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package health
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -50,6 +51,63 @@ func TestWorseStatus(t *testing.T) {
 			assert.Equal(t, tt.expected, worseStatus(tt.a, tt.b))
 		})
 	}
+}
+
+func TestCheckCephClusterHealth(t *testing.T) {
+	t.Run("HEALTH_OK no details", func(t *testing.T) {
+		status := cephStatus{Health: healthStatus{Status: "HEALTH_OK"}}
+		result := checkCephClusterHealth(status, nil)
+		assert.Equal(t, StatusOK, result.Status)
+		assert.Equal(t, "HEALTH_OK", result.Message)
+		assert.Empty(t, result.Details)
+	})
+
+	t.Run("HEALTH_WARN with checks", func(t *testing.T) {
+		status := cephStatus{Health: healthStatus{
+			Status: "HEALTH_WARN",
+			Checks: map[string]healthCheckEntry{
+				"TOO_FEW_OSDS": {
+					Severity: "HEALTH_WARN",
+					Summary:  healthCheckSummary{Message: "OSD count 1 < osd_pool_default_size 3"},
+				},
+			},
+		}}
+		result := checkCephClusterHealth(status, nil)
+		assert.Equal(t, StatusWarning, result.Status)
+		assert.Len(t, result.Details, 1)
+		assert.Contains(t, result.Details[0], "[WARN]")
+		assert.Contains(t, result.Details[0], "TOO_FEW_OSDS")
+		assert.Contains(t, result.Details[0], "OSD count 1")
+	})
+
+	t.Run("HEALTH_ERR with checks", func(t *testing.T) {
+		status := cephStatus{Health: healthStatus{
+			Status: "HEALTH_ERR",
+			Checks: map[string]healthCheckEntry{
+				"OSD_DOWN": {
+					Severity: "HEALTH_ERR",
+					Summary:  healthCheckSummary{Message: "1 osds down"},
+				},
+				"PG_DEGRADED": {
+					Severity: "HEALTH_WARN",
+					Summary:  healthCheckSummary{Message: "Degraded data redundancy: 10 pgs degraded"},
+				},
+			},
+		}}
+		result := checkCephClusterHealth(status, nil)
+		assert.Equal(t, StatusCritical, result.Status)
+		assert.Len(t, result.Details, 2)
+
+		joined := fmt.Sprintf("%v", result.Details)
+		assert.Contains(t, joined, "[ERR] OSD_DOWN: 1 osds down")
+		assert.Contains(t, joined, "[WARN] PG_DEGRADED: Degraded data redundancy")
+	})
+
+	t.Run("error fetching status", func(t *testing.T) {
+		result := checkCephClusterHealth(cephStatus{}, fmt.Errorf("connection refused"))
+		assert.Equal(t, StatusError, result.Status)
+		assert.Contains(t, result.Message, "connection refused")
+	})
 }
 
 func TestEvaluateMonQuorum(t *testing.T) {

--- a/pkg/health/types.go
+++ b/pkg/health/types.go
@@ -39,6 +39,7 @@ const (
 	CheckPGStatus             = "PG Status"
 	CheckMGRStatus            = "MGR Status"
 	CheckNodeResourcePressure = "Node Resource Pressure"
+	CheckClusterCapacity      = "Cluster Capacity"
 )
 
 // CheckResult represents the outcome of a single health check.


### PR DESCRIPTION
this commit adds cluster capacity to the
health command

```
 ./bin/kubectl-rook-ceph -n openshift-storage health 
Checking Ceph status...
Checking Mon Distribution...
Checking Ceph Cluster Health...
Checking OSD Distribution...
Checking Pods Status...
Checking PG Status...
Checking MGR Status...
Checking Cluster Capacity...

========================================================================
CLUSTER HEALTH REPORT
========================================================================
Generated: 2026-07-27 14:21:18 UTC
Namespace: openshift-storage

========================================================================
Storage
========================================================================

[OK] Ceph Cluster Health [OK]
	Status: HEALTH_OK

[OK] PG Status [OK]
	Status: 169 PGs in healthy state
	Details:
		- PgState: active+clean, PgCount: 169

[OK] Cluster Capacity [OK]
	Status: Cluster capacity 5.9% used (17.6 GiB / 300.0 GiB)

========================================================================
K8s Resources
========================================================================

[OK] Mon Distribution [OK]
	Status: 3 mon pods running on 3 different nodes
	Details:
		- 3/3 mons in quorum

[OK] OSD Distribution [OK]
	Status: 3 osd pods running on 3 different nodes

[OK] Pods Status [OK]
	Status: All 43 pods are Running/Succeeded
	Details:
		- 43 Running/Succeeded across checked namespaces

[OK] MGR Status [OK]
	Status: 2 mgr pod(s) running

========================================================================
SUMMARY
========================================================================
Total Checks: 7
OK:           7
```
```
ypadia:kubectl-rook-ceph$ ./bin/kubectl-rook-ceph -n openshift-storage health --verbose
Checking Ceph status...
Checking Mon Distribution...
Checking Ceph Cluster Health...
Checking OSD Distribution...
Checking Pods Status...
Checking PG Status...
Checking MGR Status...
Checking Cluster Capacity...

========================================================================
CLUSTER HEALTH REPORT
========================================================================
Generated: 2026-07-27 14:22:06 UTC
Namespace: openshift-storage

========================================================================
Storage
========================================================================

[OK] Ceph Cluster Health [OK]
	Status: HEALTH_OK

[OK] PG Status [OK]
	Status: 169 PGs in healthy state
	Details:
		- PgState: active+clean, PgCount: 169

[OK] Cluster Capacity [OK]
	Status: Cluster capacity 5.9% used (17.6 GiB / 300.0 GiB)
		- ocs-storagecluster-cephblockpool ()
		- ocs-storagecluster-cephobjectstore.rgw.buckets.non-ec ()
		- ocs-storagecluster-cephobjectstore.rgw.control ()
		- ocs-storagecluster-cephobjectstore.rgw.buckets.index ()
		- ocs-storagecluster-cephobjectstore.rgw.otp ()
		- ocs-storagecluster-cephobjectstore.rgw.log ()
		- .rgw.root ()
		- ocs-storagecluster-cephobjectstore.rgw.meta ()
		- ocs-storagecluster-cephfilesystem-metadata ()
		- ocs-storagecluster-cephobjectstore.rgw.buckets.data ()
		- ocs-storagecluster-cephfilesystem-data0 ()
		- .mgr ()

========================================================================
K8s Resources
========================================================================

[OK] Mon Distribution [OK]
	Status: 3 mon pods running on 3 different nodes
	Details:
		- 3/3 mons in quorum
		- rook-ceph-mon-a-668687466c-k6sp2 -> degaikwa-418vs-j8g8j-worker-0-jntjw (Running)
		- rook-ceph-mon-b-79f5bfc86f-zgnsp -> degaikwa-418vs-j8g8j-worker-0-l2b5w (Running)
		- rook-ceph-mon-c-7c675498f5-m5gd2 -> degaikwa-418vs-j8g8j-worker-0-9tplz (Running)

[OK] OSD Distribution [OK]
	Status: 3 osd pods running on 3 different nodes
		- rook-ceph-osd-0-7d96756f9f-z5rzg -> degaikwa-418vs-j8g8j-worker-0-l2b5w (Running)
		- rook-ceph-osd-1-5dc6c44c78-lqzvq -> degaikwa-418vs-j8g8j-worker-0-9tplz (Running)
		- rook-ceph-osd-2-6b8679798-hvg2r -> degaikwa-418vs-j8g8j-worker-0-jntjw (Running)

[OK] Pods Status [OK]
	Status: All 43 pods are Running/Succeeded
	Details:
		- 43 Running/Succeeded across checked namespaces

[OK] MGR Status [OK]
	Status: 2 mgr pod(s) running
		- rook-ceph-mgr-a-6678c798d6-f79st -> degaikwa-418vs-j8g8j-worker-0-l2b5w (Running)
		- rook-ceph-mgr-b-79b6556b67-6hpcx -> degaikwa-418vs-j8g8j-worker-0-jntjw (Running)

========================================================================
SUMMARY
========================================================================
Total Checks: 7
OK:           7
```