### PR TITLE
operator: add logs command to read the operator log

### DIFF
--- a/.github/workflows/go-test-config/action.yaml
+++ b/.github/workflows/go-test-config/action.yaml
@@ -262,6 +262,14 @@ runs:
         kubectl rook-ceph ${NS_OPT} rook status all
         kubectl rook-ceph ${NS_OPT} rook status cephobjectstores
 
+    - name: Print operator logs
+      shell: bash --noprofile --norc -eo pipefail -x {0}
+      run: |
+        set -ex
+        kubectl rook-ceph ${NS_OPT} operator logs --tail 20
+        kubectl rook-ceph ${NS_OPT} operator logs --tail 5 --timestamps
+        kubectl rook-ceph ${NS_OPT} operator logs --since 5m --tail 5
+
     - name: Restart operator pod
       shell: bash --noprofile --norc -eo pipefail -x {0}
       run: |

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ These are args currently supported:
 - `operator`
   - `restart` : Restart the Rook-Ceph operator
   - `set <property> <value>` : Set the property in the rook-ceph-operator-config configmap.
+  - `logs [-f] [--tail <lines>] [-p] [--since <duration>] [--timestamps]` : Print or stream the logs of the Rook operator pod
 
 - `rook`
   - `version`     : Print the version of Rook
@@ -114,6 +115,7 @@ Visit docs below for complete details about each command and their flags uses.
 1. [Get cluster health status](docs/health.md)
 1. [Update configmap rook-ceph-operator-config](docs/operator.md#set)
 1. [Restart operator pod](docs/operator.md#restart)
+1. [Get operator logs](docs/operator.md#logs)
 1. [Get rook version](docs/rook.md#version)
 1. [Get all CR status](docs/rook.md#status-all)
 1. [Get cephCluster CR status](docs/rook.md#status)

--- a/cmd/commands/operator.go
+++ b/cmd/commands/operator.go
@@ -17,8 +17,24 @@ limitations under the License.
 package command
 
 import (
+	"fmt"
+	"math"
+	"os"
+	"time"
+
 	k8sutil "github.com/rook/kubectl-rook-ceph/pkg/k8sutil"
+	"github.com/rook/kubectl-rook-ceph/pkg/logging"
 	"github.com/spf13/cobra"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+var (
+	logsFollow     bool
+	logsPrevious   bool
+	logsTimestamps bool
+	logsTail       int64
+	logsSince      time.Duration
 )
 
 // OperatorCmd represents the operator commands
@@ -51,7 +67,60 @@ var setCmd = &cobra.Command{
 	},
 }
 
+var logsCmd = &cobra.Command{
+	Use:     "logs",
+	Short:   "Print the logs of the rook-ceph operator pod",
+	Args:    cobra.NoArgs,
+	Example: "kubectl rook-ceph operator logs -f",
+	PreRunE: func(_ *cobra.Command, _ []string) error {
+		return validateLogsFlags(logsTail, logsSince)
+	},
+	Run: func(cmd *cobra.Command, _ []string) {
+		opts := logOptions(logsFollow, logsPrevious, logsTimestamps, logsTail, logsSince)
+		err := k8sutil.StreamPodLogs(cmd.Context(), clientSets.Kube, operatorNamespace, "app=rook-ceph-operator", opts, os.Stdout)
+		if err != nil {
+			logging.Fatal(err)
+		}
+	},
+}
+
 func init() {
 	OperatorCmd.AddCommand(restartCmd)
 	OperatorCmd.AddCommand(setCmd)
+	OperatorCmd.AddCommand(logsCmd)
+	logsCmd.Flags().BoolVarP(&logsFollow, "follow", "f", false, "specify if the logs should be streamed")
+	logsCmd.Flags().BoolVarP(&logsPrevious, "previous", "p", false, "print the logs for the previous instance of the container if it crashed")
+	logsCmd.Flags().BoolVar(&logsTimestamps, "timestamps", false, "include timestamps on each line in the log output")
+	logsCmd.Flags().Int64Var(&logsTail, "tail", -1, "lines of recent log file to display, defaults to all")
+	logsCmd.Flags().DurationVar(&logsSince, "since", 0, "only return logs newer than a relative duration like 5s, 2m, or 3h")
+}
+
+func validateLogsFlags(tail int64, since time.Duration) error {
+	if tail < -1 {
+		return fmt.Errorf("invalid --tail %d, must be greater than or equal to -1", tail)
+	}
+	if since < 0 {
+		return fmt.Errorf("invalid --since %s, must not be negative", since)
+	}
+
+	return nil
+}
+
+func logOptions(follow, previous, timestamps bool, tail int64, since time.Duration) *corev1.PodLogOptions {
+	opts := &corev1.PodLogOptions{
+		Container:  "rook-ceph-operator",
+		Follow:     follow,
+		Previous:   previous,
+		Timestamps: timestamps,
+	}
+	if tail >= 0 {
+		opts.TailLines = &tail
+	}
+	if since > 0 {
+		// round up: truncating a sub-second duration to 0 would mean "no limit" rather than "almost none"
+		sinceSeconds := int64(math.Ceil(since.Seconds()))
+		opts.SinceSeconds = &sinceSeconds
+	}
+
+	return opts
 }

--- a/cmd/commands/operator_test.go
+++ b/cmd/commands/operator_test.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2026 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package command
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogsCmdFlags(t *testing.T) {
+	tests := []struct {
+		name      string
+		shorthand string
+		defValue  string
+	}{
+		{name: "follow", shorthand: "f", defValue: "false"},
+		{name: "previous", shorthand: "p", defValue: "false"},
+		{name: "timestamps", shorthand: "", defValue: "false"},
+		{name: "tail", shorthand: "", defValue: "-1"},
+		{name: "since", shorthand: "", defValue: "0s"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			flag := logsCmd.Flags().Lookup(tt.name)
+			require.NotNil(t, flag, "expected --%s flag to be registered", tt.name)
+			assert.Equal(t, tt.shorthand, flag.Shorthand)
+			assert.Equal(t, tt.defValue, flag.DefValue)
+		})
+	}
+}
+
+func TestLogsCmdRegistered(t *testing.T) {
+	for _, cmd := range OperatorCmd.Commands() {
+		if cmd.Name() == "logs" {
+			return
+		}
+	}
+	t.Fatal("expected the logs sub-command to be registered on OperatorCmd")
+}
+
+func Test_validateLogsFlags(t *testing.T) {
+	tests := []struct {
+		name    string
+		tail    int64
+		since   time.Duration
+		wantErr string
+	}{
+		{name: "defaults", tail: -1, since: 0},
+		{name: "tail of zero lines", tail: 0, since: 0},
+		{name: "positive tail and since", tail: 20, since: 5 * time.Minute},
+		{name: "tail below -1", tail: -2, wantErr: "invalid --tail -2"},
+		{name: "negative since", tail: -1, since: -time.Second, wantErr: "invalid --since -1s"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateLogsFlags(tt.tail, tt.since)
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func Test_logOptions(t *testing.T) {
+	tests := []struct {
+		name          string
+		follow        bool
+		previous      bool
+		timestamps    bool
+		tail          int64
+		since         time.Duration
+		wantTail      *int64
+		wantSinceSecs *int64
+	}{
+		{
+			name: "defaults leave both limits unset",
+			tail: -1,
+		},
+		{
+			name:     "explicit tail is passed through",
+			tail:     20,
+			wantTail: ptr(int64(20)),
+		},
+		{
+			name:     "tail of zero means zero lines, not all lines",
+			tail:     0,
+			wantTail: ptr(int64(0)),
+		},
+		{
+			name:          "since is converted to seconds",
+			tail:          -1,
+			since:         5 * time.Minute,
+			wantSinceSecs: ptr(int64(300)),
+		},
+		{
+			name:          "sub-second since rounds up so it still limits output",
+			tail:          -1,
+			since:         400 * time.Millisecond,
+			wantSinceSecs: ptr(int64(1)),
+		},
+		{
+			name:          "fractional since rounds up",
+			tail:          -1,
+			since:         1500 * time.Millisecond,
+			wantSinceSecs: ptr(int64(2)),
+		},
+		{
+			name:       "boolean flags are passed through",
+			follow:     true,
+			previous:   true,
+			timestamps: true,
+			tail:       -1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := logOptions(tt.follow, tt.previous, tt.timestamps, tt.tail, tt.since)
+
+			assert.Equal(t, "rook-ceph-operator", opts.Container)
+			assert.Equal(t, tt.follow, opts.Follow)
+			assert.Equal(t, tt.previous, opts.Previous)
+			assert.Equal(t, tt.timestamps, opts.Timestamps)
+			assert.Equal(t, tt.wantTail, opts.TailLines)
+			assert.Equal(t, tt.wantSinceSecs, opts.SinceSeconds)
+		})
+	}
+}
+
+func ptr(v int64) *int64 {
+	return &v
+}

--- a/docs/operator.md
+++ b/docs/operator.md
@@ -4,6 +4,7 @@ Operator is parent command which requires sub-command. Currently, operator suppo
 
 1. `restart`: [restart](#restart) the Rook-Ceph operator
 2. `set <property> <value>` : [set](#set) the property in the rook-ceph-operator-config configmap.
+3. `logs`: [logs](#logs) print the logs of the rook-ceph operator pod
 
 ## Restart
 
@@ -23,4 +24,52 @@ Set the property in the rook-ceph-operator-config configmap
 kubectl rook-ceph operator set ROOK_LOG_LEVEL DEBUG
 
 # configmap/rook-ceph-operator-config patched
+```
+
+## Logs
+
+Print the logs of the rook-ceph operator pod, without needing to know its namespace or label. The
+operator namespace is the one already resolved by the plugin.
+
+The operator runs as a single replica, so the command reads from a single pod: a running one when
+several match, as happens briefly during a restart. When more than one pod matches, it reports which
+pod it chose.
+
+```bash
+kubectl rook-ceph operator logs --tail 5
+
+# 2026-01-14 09:12:03.112841 I | ceph-cluster-controller: reconciling ceph cluster in namespace "rook-ceph"
+# 2026-01-14 09:12:03.418922 I | op-mon: parsing mon endpoints: a=10.104.62.31:6789
+# 2026-01-14 09:12:04.002317 I | ceph-cluster-controller: detecting the ceph image version for image quay.io/ceph/ceph:v18
+# 2026-01-14 09:12:09.771208 I | ceph-cluster-controller: detected ceph image version: "18.2.1-0 reef"
+# 2026-01-14 09:12:10.334019 I | ceph-cluster-controller: done reconciling ceph cluster in namespace "rook-ceph"
+```
+
+The following flags are supported, all matching their `kubectl logs` counterparts:
+
+| Flag | Description |
+| --- | --- |
+| `-f`, `--follow` | Stream the logs until interrupted, reconnecting across operator restarts |
+| `--tail <lines>` | Show only the most recent lines (default: all) |
+| `-p`, `--previous` | Show the logs of the previous container instance, for an operator that has crashed |
+| `--since <duration>` | Show only logs newer than a relative duration such as `5s`, `2m`, or `3h` |
+| `--timestamps` | Prefix every line with a timestamp |
+
+Stream the logs of a running operator:
+
+```bash
+kubectl rook-ceph operator logs -f
+```
+
+`--follow` keeps streaming until it is interrupted, reattaching when the operator container crashes
+or is rolled onto a replacement pod. This differs from `kubectl logs -f`, which exits as soon as the
+container it attached to does — the point being that an operator restart is usually the event worth
+watching, not a reason to stop watching. A replacement pod is read from the beginning of its log; a
+container that restarted in place resumes from where the previous stream left off, which may repeat
+a line or two.
+
+Read the logs an operator emitted before it crashed:
+
+```bash
+kubectl rook-ceph operator logs -p
 ```

--- a/pkg/k8sutil/logs.go
+++ b/pkg/k8sutil/logs.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2026 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package k8sutil
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/rook/kubectl-rook-ceph/pkg/logging"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const logReconnectInterval = 2 * time.Second
+
+// StreamPodLogs copies the logs of the pod matching labelSelector to out. Unlike WaitForPodToRun it
+// does not wait for the pod to be running, so logs remain reachable while a pod is crash looping or
+// stuck pending.
+//
+// When opts.Follow is set the stream is re-established after it ends, so following a deployment
+// survives a container crash or a rollout onto a replacement pod. This deliberately differs from
+// `kubectl logs -f`, which stops as soon as the container it attached to exits.
+func StreamPodLogs(ctx context.Context, k8sclientset kubernetes.Interface, namespace, labelSelector string, opts *corev1.PodLogOptions, out io.Writer) error {
+	var (
+		lastPod  string
+		lastRead time.Time
+	)
+
+	for attempt := 0; ; attempt++ {
+		pod, matches, err := findPodForLogs(ctx, k8sclientset, namespace, labelSelector)
+		if err != nil {
+			// Fail fast while nothing has been read yet. Once following, a missing pod only means
+			// its replacement has not been created yet.
+			if attempt == 0 || !opts.Follow {
+				return err
+			}
+			if !waitBeforeReconnect(ctx) {
+				return nil
+			}
+			continue
+		}
+
+		if pod.Name != lastPod {
+			if matches > 1 {
+				logging.Warning("%d pods match label %q in namespace %q, showing logs for pod %q", matches, labelSelector, namespace, pod.Name)
+			} else if attempt > 0 {
+				logging.Info("following logs from pod %q", pod.Name)
+			}
+		}
+
+		opened, err := copyPodLogs(ctx, k8sclientset, namespace, pod.Name, reconnectOptions(opts, pod.Name, lastPod, lastRead), out)
+		if opened {
+			lastRead = time.Now()
+			lastPod = pod.Name
+		}
+		if err != nil {
+			if attempt == 0 || !opts.Follow {
+				return err
+			}
+			logging.Warning("%v, reconnecting in %s", err, logReconnectInterval)
+		}
+
+		if !opts.Follow || ctx.Err() != nil {
+			return nil
+		}
+		if !waitBeforeReconnect(ctx) {
+			return nil
+		}
+	}
+}
+
+func findPodForLogs(ctx context.Context, k8sclientset kubernetes.Interface, namespace, labelSelector string) (*corev1.Pod, int, error) {
+	pods, err := k8sclientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to list pods matching label %q in namespace %q. %w", labelSelector, namespace, err)
+	}
+
+	pod := selectPodForLogs(pods.Items)
+	if pod == nil {
+		return nil, 0, fmt.Errorf("no pod matching label %q found in namespace %q", labelSelector, namespace)
+	}
+
+	return pod, len(pods.Items), nil
+}
+
+// copyPodLogs reports whether the stream was opened, so that a caller following the logs can tell a
+// stream that ended from one that never started.
+func copyPodLogs(ctx context.Context, k8sclientset kubernetes.Interface, namespace, podName string, opts *corev1.PodLogOptions, out io.Writer) (bool, error) {
+	stream, err := k8sclientset.CoreV1().Pods(namespace).GetLogs(podName, opts).Stream(ctx)
+	if err != nil {
+		return false, fmt.Errorf("failed to get logs for pod %q. %w", podName, err)
+	}
+	defer stream.Close()
+
+	if _, err := io.Copy(out, stream); err != nil {
+		return true, fmt.Errorf("failed to stream logs for pod %q. %w", podName, err)
+	}
+
+	return true, nil
+}
+
+// reconnectOptions adapts the caller's options for a re-established stream. --tail and --previous
+// describe the first connection only, and reattaching to a pod already read from must skip what was
+// printed before. A replacement pod is read from its beginning, since a rollout can start it before
+// the outgoing pod's stream ends.
+func reconnectOptions(opts *corev1.PodLogOptions, podName, lastPod string, lastRead time.Time) *corev1.PodLogOptions {
+	if lastPod == "" {
+		return opts
+	}
+
+	next := *opts
+	next.TailLines = nil
+	next.Previous = false
+	if podName == lastPod {
+		// A second of overlap costs a few duplicate lines and avoids dropping any to clock skew
+		// between this host and the node.
+		since := metav1.NewTime(lastRead.Add(-time.Second))
+		next.SinceTime = &since
+		next.SinceSeconds = nil
+	}
+
+	return &next
+}
+
+func waitBeforeReconnect(ctx context.Context) bool {
+	select {
+	case <-ctx.Done():
+		return false
+	case <-time.After(logReconnectInterval):
+		return true
+	}
+}
+
+// selectPodForLogs prefers a running pod that is not terminating, so that a rollout leaving both an
+// old and a new pod behind reads from the live one. It falls back to the first pod so that logs of a
+// pending or crash looping pod are still reachable.
+func selectPodForLogs(pods []corev1.Pod) *corev1.Pod {
+	if len(pods) == 0 {
+		return nil
+	}
+
+	for i := range pods {
+		if pods[i].Status.Phase == corev1.PodRunning && pods[i].DeletionTimestamp.IsZero() {
+			return &pods[i]
+		}
+	}
+
+	return &pods[0]
+}

--- a/pkg/k8sutil/logs_test.go
+++ b/pkg/k8sutil/logs_test.go
@@ -1,0 +1,211 @@
+/*
+Copyright 2026 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package k8sutil
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func testPod(name string, phase corev1.PodPhase, terminating bool) corev1.Pod {
+	pod := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "rook-ceph",
+			Labels:    map[string]string{"app": "rook-ceph-operator"},
+		},
+		Status: corev1.PodStatus{Phase: phase},
+	}
+	if terminating {
+		now := metav1.NewTime(time.Now())
+		pod.DeletionTimestamp = &now
+		pod.Finalizers = []string{"test/finalizer"}
+	}
+	return pod
+}
+
+func TestSelectPodForLogs(t *testing.T) {
+	tests := []struct {
+		name string
+		pods []corev1.Pod
+		want string
+	}{
+		{
+			name: "no pods",
+			pods: nil,
+			want: "",
+		},
+		{
+			name: "single running pod",
+			pods: []corev1.Pod{testPod("operator-a", corev1.PodRunning, false)},
+			want: "operator-a",
+		},
+		{
+			name: "prefers the running pod over a pending one",
+			pods: []corev1.Pod{
+				testPod("operator-pending", corev1.PodPending, false),
+				testPod("operator-running", corev1.PodRunning, false),
+			},
+			want: "operator-running",
+		},
+		{
+			name: "skips a terminating pod during a rollout",
+			pods: []corev1.Pod{
+				testPod("operator-old", corev1.PodRunning, true),
+				testPod("operator-new", corev1.PodRunning, false),
+			},
+			want: "operator-new",
+		},
+		{
+			name: "falls back to the first pod when none are running",
+			pods: []corev1.Pod{
+				testPod("operator-pending", corev1.PodPending, false),
+				testPod("operator-failed", corev1.PodFailed, false),
+			},
+			want: "operator-pending",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pod := selectPodForLogs(tt.pods)
+			if tt.want == "" {
+				assert.Nil(t, pod)
+				return
+			}
+			require.NotNil(t, pod)
+			assert.Equal(t, tt.want, pod.Name)
+		})
+	}
+}
+
+func TestStreamPodLogs(t *testing.T) {
+	ctx := context.TODO()
+
+	t.Run("no pod matches the label", func(t *testing.T) {
+		client := fake.NewSimpleClientset()
+		var out bytes.Buffer
+
+		err := StreamPodLogs(ctx, client, "rook-ceph", "app=rook-ceph-operator", &corev1.PodLogOptions{}, &out)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no pod matching label")
+		assert.Empty(t, out.String())
+	})
+
+	t.Run("pods in the namespace that do not match the label are ignored", func(t *testing.T) {
+		other := testPod("some-other-pod", corev1.PodRunning, false)
+		other.Labels = map[string]string{"app": "rook-ceph-tools"}
+		client := fake.NewSimpleClientset(&other)
+		var out bytes.Buffer
+
+		err := StreamPodLogs(ctx, client, "rook-ceph", "app=rook-ceph-operator", &corev1.PodLogOptions{}, &out)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no pod matching label")
+	})
+
+	t.Run("copies the log stream to the writer", func(t *testing.T) {
+		pod := testPod("operator-a", corev1.PodRunning, false)
+		client := fake.NewSimpleClientset(&pod)
+		var out bytes.Buffer
+
+		err := StreamPodLogs(ctx, client, "rook-ceph", "app=rook-ceph-operator", &corev1.PodLogOptions{}, &out)
+		require.NoError(t, err)
+		assert.Equal(t, "fake logs", out.String())
+	})
+}
+
+func TestStreamPodLogsFollow(t *testing.T) {
+	t.Run("fails fast when there is nothing to follow", func(t *testing.T) {
+		client := fake.NewSimpleClientset()
+		var out bytes.Buffer
+
+		err := StreamPodLogs(context.TODO(), client, "rook-ceph", "app=rook-ceph-operator", &corev1.PodLogOptions{Follow: true}, &out)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no pod matching label")
+	})
+
+	t.Run("stops reconnecting when the context is cancelled", func(t *testing.T) {
+		pod := testPod("operator-a", corev1.PodRunning, false)
+		client := fake.NewSimpleClientset(&pod)
+		var out bytes.Buffer
+
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+
+		err := StreamPodLogs(ctx, client, "rook-ceph", "app=rook-ceph-operator", &corev1.PodLogOptions{Follow: true}, &out)
+		require.NoError(t, err)
+		assert.Equal(t, "fake logs", out.String())
+	})
+}
+
+func TestReconnectOptions(t *testing.T) {
+	lastRead := time.Date(2026, 7, 29, 16, 44, 55, 0, time.UTC)
+	tail := int64(5)
+	sinceSeconds := int64(300)
+	original := &corev1.PodLogOptions{
+		Container:    "rook-ceph-operator",
+		Follow:       true,
+		Previous:     true,
+		Timestamps:   true,
+		TailLines:    &tail,
+		SinceSeconds: &sinceSeconds,
+	}
+
+	t.Run("the first connection uses the caller's options unchanged", func(t *testing.T) {
+		opts := reconnectOptions(original, "operator-a", "", time.Time{})
+		assert.Same(t, original, opts)
+	})
+
+	t.Run("reattaching to the same pod resumes from the checkpoint", func(t *testing.T) {
+		opts := reconnectOptions(original, "operator-a", "operator-a", lastRead)
+
+		require.NotNil(t, opts.SinceTime)
+		assert.Equal(t, lastRead.Add(-time.Second), opts.SinceTime.Time)
+		// SinceTime and SinceSeconds are mutually exclusive, the apiserver rejects both
+		assert.Nil(t, opts.SinceSeconds)
+		assert.Nil(t, opts.TailLines)
+		assert.False(t, opts.Previous)
+		assert.True(t, opts.Follow)
+		assert.True(t, opts.Timestamps)
+	})
+
+	t.Run("a replacement pod is read from its beginning", func(t *testing.T) {
+		opts := reconnectOptions(original, "operator-b", "operator-a", lastRead)
+
+		assert.Nil(t, opts.SinceTime)
+		assert.Nil(t, opts.TailLines)
+		assert.False(t, opts.Previous)
+	})
+
+	t.Run("the caller's options are not mutated", func(t *testing.T) {
+		reconnectOptions(original, "operator-b", "operator-a", lastRead)
+
+		assert.Equal(t, &tail, original.TailLines)
+		assert.Equal(t, &sinceSeconds, original.SinceSeconds)
+		assert.True(t, original.Previous)
+		assert.Nil(t, original.SinceTime)
+	})
+}


### PR DESCRIPTION
**Motivation**

Watching the Rook operator log means restarting the watch every time the operator restarts: `kubectl logs -f` exits as soon as the container it attached to does, which is usually the event most worth watching.

**What changed**

`kubectl rook-ceph operator logs` reads the operator log from the namespace the plugin already resolves, with `-f/--follow`, `--tail`, `-p/--previous`, `--since` and `--timestamps`. `--follow` re-establishes the stream after it ends, so it rides through a container crash or a rollout onto a replacement pod.

**Notable decisions**

- A replacement pod is read from the start of its log; a container restarted in place resumes from a checkpoint one second back, so a line may repeat rather than be lost to clock skew.
- Skips the exec-based operator readiness check the sibling subcommands run, since it fails in precisely the crash-looping case where the log matters most.
- Reads one pod (the Deployment is single-replica); when several match, a running non-terminating one is preferred and named on stderr.

AI assistance: Claude wrote the implementation, tests and docs from an interactively agreed design; an adversarial review pass it ran surfaced the missing flag validation and the follow-stops-at-container-exit limitation this PR then addressed.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
