### PR TITLE
core: implement exec command to quickly exec into rook-ceph pods

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ These are args currently supported:
 
 - `rbd <args>` : Call a 'rbd' CLI command with arbitrary args
 
+- `exec [component]` : Open an interactive Bash shell in the operator, toolbox, or a Ceph daemon pod. The component defaults to `toolbox`; it can also be `operator`, `mon-<id>`, `mgr-<id>`, `osd-<id>`, `mds-<id>`, or `rgw-<id>`.
+
 - `mons` : Print mon endpoints
   - `restore-quorum <mon-name>` : Restore the mon quorum based on a single healthy mon since quorum was lost with the other mons
 
@@ -127,6 +129,7 @@ Visit docs below for complete details about each command and their flags uses.
 1. [Restore deleted CRs](docs/crd.md)
 1. [Destroy cluster](docs/destroy-cluster.md)
 1. [Running rados commands](docs/rados.md)
+1. [Open a component shell](docs/exec.md)
 1. [Multus validation](docs/multus.md)
 1. [Subvolume cleanup](docs/subvolume.md)
 1. [Snapshot cleanup](docs/cephfs-snapshots.md)

--- a/cmd/commands/custom_exec.go
+++ b/cmd/commands/custom_exec.go
@@ -18,10 +18,73 @@ package command
 
 import (
 	"fmt"
+	"strings"
 
+	"github.com/rook/kubectl-rook-ceph/pkg/exec"
 	"github.com/rook/kubectl-rook-ceph/pkg/filesystem"
+	"github.com/rook/kubectl-rook-ceph/pkg/logging"
 	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/util/validation"
 )
+
+var ExecCmd = &cobra.Command{
+	Use:   "exec [component]",
+	Short: "Open an interactive shell in a Rook Ceph component",
+	Long: "Open an interactive shell in the Rook Ceph operator, toolbox, or a Ceph daemon pod.\n\n" +
+		"The component defaults to toolbox and can also be operator, mon-<id>, mgr-<id>, osd-<id>, mds-<id>, or rgw-<id>.",
+	Args: func(cmd *cobra.Command, args []string) error {
+		if err := cobra.MaximumNArgs(1)(cmd, args); err != nil {
+			return err
+		}
+		_, _, err := execTarget(args)
+		return err
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		labelSelector, container, err := execTarget(args)
+		if err != nil {
+			logging.Fatal(err)
+		}
+		namespace := cephClusterNamespace
+		if container == "rook-ceph-operator" {
+			namespace = operatorNamespace
+		}
+		if err := exec.RunShellInLabeledPod(cmd.Context(), clientSets, namespace, labelSelector, container); err != nil {
+			logging.Fatal(err)
+		}
+	},
+}
+
+func execTarget(args []string) (string, string, error) {
+	component := "toolbox"
+	if len(args) == 1 {
+		component = args[0]
+	}
+
+	if component == "toolbox" {
+		return "app=rook-ceph-tools", "rook-ceph-tools", nil
+	}
+	if component == "operator" {
+		return "app=rook-ceph-operator", "rook-ceph-operator", nil
+	}
+
+	daemonType, daemonID, found := strings.Cut(component, "-")
+	if !found || daemonID == "" || len(validation.IsValidLabelValue(daemonID)) != 0 {
+		return "", "", invalidExecComponent(component)
+	}
+
+	switch daemonType {
+	case "mon":
+		return fmt.Sprintf("app=rook-ceph-mon,mon=%s,mon_canary!=true", daemonID), daemonType, nil
+	case "mgr", "osd", "mds", "rgw":
+		return fmt.Sprintf("app=rook-ceph-%s,%s=%s", daemonType, daemonType, daemonID), daemonType, nil
+	default:
+		return "", "", invalidExecComponent(component)
+	}
+}
+
+func invalidExecComponent(component string) error {
+	return fmt.Errorf("invalid component %q: expected toolbox, operator, mon-<id>, mgr-<id>, osd-<id>, mds-<id>, or rgw-<id>", component)
+}
 
 func addCustomExecFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().String("pod-name", "", "Pod to execute commands in")

--- a/cmd/commands/custom_exec_test.go
+++ b/cmd/commands/custom_exec_test.go
@@ -1,0 +1,84 @@
+package command
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExecTarget(t *testing.T) {
+	tests := []struct {
+		name          string
+		args          []string
+		wantSelector  string
+		wantContainer string
+		wantErr       string
+	}{
+		{
+			name:          "default toolbox",
+			wantSelector:  "app=rook-ceph-tools",
+			wantContainer: "rook-ceph-tools",
+		},
+		{
+			name:          "toolbox",
+			args:          []string{"toolbox"},
+			wantSelector:  "app=rook-ceph-tools",
+			wantContainer: "rook-ceph-tools",
+		},
+		{
+			name:          "operator",
+			args:          []string{"operator"},
+			wantSelector:  "app=rook-ceph-operator",
+			wantContainer: "rook-ceph-operator",
+		},
+		{
+			name:          "mon",
+			args:          []string{"mon-a"},
+			wantSelector:  "app=rook-ceph-mon,mon=a,mon_canary!=true",
+			wantContainer: "mon",
+		},
+		{
+			name:          "mgr",
+			args:          []string{"mgr-b"},
+			wantSelector:  "app=rook-ceph-mgr,mgr=b",
+			wantContainer: "mgr",
+		},
+		{
+			name:          "osd",
+			args:          []string{"osd-42"},
+			wantSelector:  "app=rook-ceph-osd,osd=42",
+			wantContainer: "osd",
+		},
+		{
+			name:    "missing daemon ID",
+			args:    []string{"mon-"},
+			wantErr: `invalid component "mon-": expected toolbox, operator, mon-<id>, mgr-<id>, osd-<id>, mds-<id>, or rgw-<id>`,
+		},
+		{
+			name:    "unsupported component",
+			args:    []string{"nfs-a"},
+			wantErr: `invalid component "nfs-a": expected toolbox, operator, mon-<id>, mgr-<id>, osd-<id>, mds-<id>, or rgw-<id>`,
+		},
+		{
+			name:    "invalid daemon ID",
+			args:    []string{"osd-bad/value"},
+			wantErr: `invalid component "osd-bad/value": expected toolbox, operator, mon-<id>, mgr-<id>, osd-<id>, mds-<id>, or rgw-<id>`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			selector, container, err := execTarget(tt.args)
+			if tt.wantErr != "" {
+				assert.EqualError(t, err, tt.wantErr)
+				assert.Empty(t, selector)
+				assert.Empty(t, container)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantSelector, selector)
+			assert.Equal(t, tt.wantContainer, container)
+		})
+	}
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -16,13 +16,20 @@ limitations under the License.
 package main
 
 import (
+	"context"
+	"os/signal"
+	"syscall"
+
 	command "github.com/rook/kubectl-rook-ceph/cmd/commands"
 	"github.com/rook/kubectl-rook-ceph/pkg/logging"
 )
 
 func main() {
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
 	addcommands()
-	err := command.RootCmd.Execute()
+	err := command.RootCmd.ExecuteContext(ctx)
 	if err != nil {
 		logging.Fatal(err)
 	}
@@ -46,5 +53,6 @@ func addcommands() {
 		command.RadosgwCmd,
 		command.MultusCmd,
 		command.CephFSSnapshotCmd,
+		command.ExecCmd,
 	)
 }

--- a/docs/exec.md
+++ b/docs/exec.md
@@ -1,0 +1,46 @@
+# Exec
+
+The `exec` command opens an interactive Bash shell in a Rook Ceph component pod. If no component is specified, it opens a shell in the toolbox pod.
+
+The target pod must be running, and the current Kubernetes user must have permission to list pods and execute commands in it. The toolbox and Ceph daemon pods are selected from the Ceph cluster namespace. The operator pod is selected from the operator namespace.
+
+## Usage
+
+Open a toolbox shell:
+
+```bash
+kubectl rook-ceph exec
+kubectl rook-ceph exec toolbox
+```
+
+Open a shell in the Rook Ceph operator:
+
+```bash
+kubectl rook-ceph exec operator
+```
+
+Open a shell in a specific Ceph daemon:
+
+```bash
+kubectl rook-ceph exec mon-a
+kubectl rook-ceph exec mgr-b
+kubectl rook-ceph exec osd-42
+kubectl rook-ceph exec mds-myfs-a
+kubectl rook-ceph exec rgw-my-store
+```
+
+For MDS, use the daemon ID shown in the pod's `mds` label. For RGW, use the object store name shown in the pod's `rgw` label.
+
+To use a component in a different namespace:
+
+```bash
+kubectl rook-ceph --namespace my-rook-ceph-namespace exec mon-a
+```
+
+To use an operator in a different namespace:
+
+```bash
+kubectl rook-ceph --operator-namespace my-operator-namespace exec operator
+```
+
+Run `exit` to leave the shell.

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.12.1
+	golang.org/x/term v0.45.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.36.4
 	k8s.io/apimachinery v0.36.4
@@ -101,7 +102,6 @@ require (
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
-	golang.org/x/term v0.45.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -24,6 +24,7 @@ import (
 	"os"
 
 	"github.com/rook/kubectl-rook-ceph/pkg/k8sutil"
+	"golang.org/x/term"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -83,6 +84,74 @@ func RunCommandInToolboxPod(ctx context.Context, clientsets *k8sutil.Clientsets,
 
 	fmt.Println(stderr.String())
 	return stdout.String(), nil
+}
+
+type terminalSizeQueue struct {
+	size *remotecommand.TerminalSize
+}
+
+func (q *terminalSizeQueue) Next() *remotecommand.TerminalSize {
+	size := q.size
+	q.size = nil
+	return size
+}
+
+func RunShellInLabeledPod(ctx context.Context, clientsets *k8sutil.Clientsets, clusterNamespace, labelSelector, container string) error {
+	pod, err := k8sutil.WaitForPodToRun(ctx, clientsets.Kube, clusterNamespace, labelSelector)
+	if err != nil {
+		return fmt.Errorf("failed to wait for pod with labels %q to run. %w", labelSelector, err)
+	}
+
+	stdin := int(os.Stdin.Fd())
+	if !term.IsTerminal(stdin) {
+		return fmt.Errorf("stdin is not a terminal")
+	}
+
+	terminalState, err := term.MakeRaw(stdin)
+	if err != nil {
+		return fmt.Errorf("failed to configure terminal. %w", err)
+	}
+	defer func() {
+		_ = term.Restore(stdin, terminalState)
+	}()
+
+	width, height, err := term.GetSize(stdin)
+	if err != nil {
+		return fmt.Errorf("failed to get terminal size. %w", err)
+	}
+
+	req := clientsets.Kube.CoreV1().RESTClient().
+		Post().
+		Namespace(pod.Namespace).
+		Resource("pods").
+		Name(pod.Name).
+		SubResource("exec").
+		VersionedParams(&v1.PodExecOptions{
+			Container: container,
+			Command:   []string{"/bin/bash"},
+			Stdin:     true,
+			Stdout:    true,
+			TTY:       true,
+		}, scheme.ParameterCodec)
+
+	executor, err := remotecommand.NewSPDYExecutor(clientsets.KubeConfig, "POST", req.URL())
+	if err != nil {
+		return fmt.Errorf("failed to create SPDYExecutor. %w", err)
+	}
+
+	err = executor.StreamWithContext(ctx, remotecommand.StreamOptions{
+		Stdin:  os.Stdin,
+		Stdout: os.Stdout,
+		Tty:    true,
+		TerminalSizeQueue: &terminalSizeQueue{size: &remotecommand.TerminalSize{
+			Width:  uint16(width),
+			Height: uint16(height),
+		}},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to open shell in pod %q. %w", pod.Name, err)
+	}
+	return nil
 }
 
 func RunCommandInLabeledPod(ctx context.Context, clientsets *k8sutil.Clientsets, label, container, cmd string, args []string, clusterNamespace string, returnOutput bool) (string, error) {


### PR DESCRIPTION
Several users have reported using a bash alias or other shortcut to exec into rook-ceph pods. Instead of relying on every user to create an alias or remember the command to exec into rook-ceph pods, we can create a command within the rook-ceph kubectl plugin.

This commit implements the `exec` command which will simply look for the pod corresponding to the ceph component and exec into that pod. The rook-ceph toolbox will be the target of the exec command if no component is specified.

Tested manually by building the plugin and putting it within my PATH:
```
$ ./kubectl rook-ceph exec
bash-5.1$ ceph status
  cluster:
    id:     34d2ae17-a372-48e2-94ee-cc28d25814b8
    health: HEALTH_WARN
            2 slow ops, oldest one blocked for 471254 sec, daemons [mon.dt,mon.dv] have slow ops.

  services:
    mon:        5 daemons, quorum dq,ds,dt,dv,dw (age 5d)
    mgr:        b(active, since 2w), standbys: a
    osd:        12 osds: 12 up (since 6d), 12 in (since 6d)
    rbd-mirror: 1 daemon active (1 hosts)
    rgw:        5 daemons active (5 hosts, 1 zones)

  data:
    pools:   10 pools, 1593 pgs
    objects: 93.74k objects, 294 GiB
    usage:   881 GiB used, 167 TiB / 168 TiB avail
    pgs:     1593 active+clean

  io:
    client:   2.2 GiB/s rd, 1.9 GiB/s wr, 7.06k op/s rd, 7.47k op/s wr

bash-5.1$ exit
```

```
$ ./kubectl rook-ceph exec mon-dq
[root@ ceph]# ps -aux
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
ceph           1  1.2  0.1 833908 487684 ?       Ssl  Aug10 250:31 ceph-mon
root      979228  0.0  0.0   4900  4184 pts/0    Ss   20:44   0:00 /bin/bash
root      979313  0.0  0.0  17692  6576 pts/0    R+   20:45   0:00 ps -aux
[root@ ceph]# exit
exit
```

```
$ ./kubectl rook-ceph exec mgr-b
[root@ ceph]# ps -aux
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
ceph           1  1.8  0.3 14770040 1028500 ?    Ssl  Aug10 369:10 ceph-mgr
root      979587  0.1  0.0   4908  4044 pts/0    Ss   20:47   0:00 /bin/bash
root      979623  0.0  0.0  17692  6656 pts/0    R+   20:47   0:00 ps -aux
[root@ ceph]# exit
exit
```

```
$ ./kubectl rook-ceph exec osd-0
[root@ ceph]# ps -aux
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
ceph           1  113  3.1 17391604 12655960 ?   Ssl  Aug04 32869:53 ceph-osd
root     1395521  0.0  0.0   4912  4200 pts/0    Ss   20:48   0:00 /bin/bash
root     1395547  0.0  0.0  17692  6852 pts/0    R+   20:48   0:00 ps -aux
[root@ ceph]# exit
exit
```

Fixes #460

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
