### PR TITLE
operator: add fs-top command to run interactive cephfs-top in operator pod

### DIFF
--- a/cmd/commands/fs_top.go
+++ b/cmd/commands/fs_top.go
@@ -36,5 +36,5 @@ var FsTopCmd = &cobra.Command{
 }
 
 func fsTopArgs(args []string, namespace string) []string {
-	return append(args, "--id=admin", "--conffile=/var/lib/rook/"+namespace+"/"+namespace+".config")
+	return append(args, "--id=admin", "--conf=/var/lib/rook/"+namespace+"/"+namespace+".config")
 }

--- a/cmd/commands/fs_top.go
+++ b/cmd/commands/fs_top.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2026 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package command
+
+import (
+	"github.com/rook/kubectl-rook-ceph/pkg/exec"
+	"github.com/rook/kubectl-rook-ceph/pkg/logging"
+	"github.com/spf13/cobra"
+)
+
+// FsTopCmd represents the fs-top command.
+var FsTopCmd = &cobra.Command{
+	Use:                "fs-top",
+	Short:              "run cephfs-top for real-time CephFS metrics",
+	DisableFlagParsing: true,
+	Run: func(cmd *cobra.Command, args []string) {
+		args = fsTopArgs(args, cephClusterNamespace)
+		if err := exec.RunInteractiveCommandInOperatorPod(cmd.Context(), clientSets, "cephfs-top", args, operatorNamespace, cephClusterNamespace); err != nil {
+			logging.Fatal(err)
+		}
+	},
+}
+
+func fsTopArgs(args []string, namespace string) []string {
+	return append(args, "--id=admin", "--conffile=/var/lib/rook/"+namespace+"/"+namespace+".config")
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -31,6 +31,7 @@ func main() {
 func addcommands() {
 	command.RootCmd.AddCommand(
 		command.CephCmd,
+		command.FsTopCmd,
 		command.MonCmd,
 		command.RbdCmd,
 		command.OperatorCmd,

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
+	golang.org/x/term v0.45.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.36.3
 	k8s.io/apimachinery v0.36.3
@@ -115,7 +116,6 @@ require (
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
-	golang.org/x/term v0.45.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.5.0 // indirect

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"time"
 
 	"github.com/rook/kubectl-rook-ceph/pkg/k8sutil"
 
@@ -194,9 +195,14 @@ func execCmdInPod(ctx context.Context, clientsets *k8sutil.Clientsets,
 
 	if tty {
 		stdinFD := int(os.Stdin.Fd())
-		if !term.IsTerminal(stdinFD) {
-			return fmt.Errorf("stdin is not a terminal")
+		stdoutFD := int(os.Stdout.Fd())
+		if !term.IsTerminal(stdinFD) || !term.IsTerminal(stdoutFD) {
+			return fmt.Errorf("interactive mode requires a TTY; avoid stdin/stdout redirection")
 		}
+
+		sizeQueue := newTerminalSizeQueue(stdoutFD)
+		defer sizeQueue.Stop()
+
 		state, err := term.MakeRaw(stdinFD)
 		if err != nil {
 			return fmt.Errorf("failed to set terminal raw mode. %w", err)
@@ -206,10 +212,11 @@ func execCmdInPod(ctx context.Context, clientsets *k8sutil.Clientsets,
 		}()
 
 		err = exec.StreamWithContext(ctx, remotecommand.StreamOptions{
-			Stdin:  os.Stdin,
-			Stdout: os.Stdout,
-			Stderr: os.Stderr,
-			Tty:    true,
+			Stdin:             os.Stdin,
+			Stdout:            os.Stdout,
+			Stderr:            os.Stderr,
+			Tty:               true,
+			TerminalSizeQueue: sizeQueue,
 		})
 	} else if !returnOutput {
 		// Connect this process' std{in,out,err} to the remote shell process.
@@ -230,4 +237,47 @@ func execCmdInPod(ctx context.Context, clientsets *k8sutil.Clientsets,
 		return fmt.Errorf("failed to run command. %w", err)
 	}
 	return nil
+}
+
+type terminalSizeQueue struct {
+	fd          int
+	width       int
+	height      int
+	initialized bool
+	stop        chan struct{}
+}
+
+func newTerminalSizeQueue(fd int) *terminalSizeQueue {
+	return &terminalSizeQueue{
+		fd:   fd,
+		stop: make(chan struct{}),
+	}
+}
+
+func (q *terminalSizeQueue) Next() *remotecommand.TerminalSize {
+	ticker := time.NewTicker(250 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		width, height, err := term.GetSize(q.fd)
+		if err != nil {
+			return nil
+		}
+		if !q.initialized || width != q.width || height != q.height {
+			q.width = width
+			q.height = height
+			q.initialized = true
+			return &remotecommand.TerminalSize{Width: uint16(width), Height: uint16(height)}
+		}
+
+		select {
+		case <-q.stop:
+			return nil
+		case <-ticker.C:
+		}
+	}
+}
+
+func (q *terminalSizeQueue) Stop() {
+	close(q.stop)
 }

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/rook/kubectl-rook-ceph/pkg/k8sutil"
 
+	"golang.org/x/term"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -47,7 +48,7 @@ func RunCommandInOperatorPod(ctx context.Context, clientsets *k8sutil.Clientsets
 
 	var stdout, stderr bytes.Buffer
 
-	err = execCmdInPod(ctx, clientsets, cmd, pod.Name, "rook-ceph-operator", pod.Namespace, clusterNamespace, args, &stdout, &stderr, returnOutput, false)
+	err = execCmdInPod(ctx, clientsets, cmd, pod.Name, "rook-ceph-operator", pod.Namespace, clusterNamespace, args, &stdout, &stderr, returnOutput, false, false)
 	if err != nil {
 		err = fmt.Errorf("%s. %w", stderr.String(), err)
 	}
@@ -56,6 +57,16 @@ func RunCommandInOperatorPod(ctx context.Context, clientsets *k8sutil.Clientsets
 		out = stdout.String()
 	}
 	return out, err
+}
+
+// RunInteractiveCommandInOperatorPod runs a command in the operator pod with stdin and a TTY attached.
+func RunInteractiveCommandInOperatorPod(ctx context.Context, clientsets *k8sutil.Clientsets, cmd string, args []string, operatorNamespace, clusterNamespace string) error {
+	pod, err := k8sutil.WaitForPodToRun(ctx, clientsets.Kube, operatorNamespace, "app=rook-ceph-operator")
+	if err != nil {
+		return fmt.Errorf("failed to wait for operator pod to run. %w", err)
+	}
+
+	return execCmdInPod(ctx, clientsets, cmd, pod.Name, "rook-ceph-operator", pod.Namespace, clusterNamespace, args, io.Discard, io.Discard, false, false, true)
 }
 
 func RunCommandInToolboxPod(ctx context.Context, clientsets *k8sutil.Clientsets, cmd string, args []string, clusterNamespace string, returnOutput bool) (string, error) {
@@ -69,7 +80,7 @@ func RunCommandInToolboxPod(ctx context.Context, clientsets *k8sutil.Clientsets,
 
 	var stdout, stderr bytes.Buffer
 
-	err = execCmdInPod(ctx, clientsets, cmd, pod.Name, "rook-ceph-tools", pod.Namespace, clusterNamespace, args, &stdout, &stderr, returnOutput, false)
+	err = execCmdInPod(ctx, clientsets, cmd, pod.Name, "rook-ceph-tools", pod.Namespace, clusterNamespace, args, &stdout, &stderr, returnOutput, false, false)
 	if err != nil {
 		err := fmt.Errorf("failed to run command. %w", err)
 		if !returnOutput {
@@ -95,7 +106,7 @@ func RunCommandInLabeledPod(ctx context.Context, clientsets *k8sutil.Clientsets,
 		return "", fmt.Errorf("failed to get rook mon pod where the command could be executed. %w", err)
 	}
 	var stdout, stderr bytes.Buffer
-	err = execCmdInPod(ctx, clientsets, cmd, list.Items[0].Name, container, list.Items[0].Namespace, clusterNamespace, args, &stdout, &stderr, returnOutput, false)
+	err = execCmdInPod(ctx, clientsets, cmd, list.Items[0].Name, container, list.Items[0].Namespace, clusterNamespace, args, &stdout, &stderr, returnOutput, false, false)
 	if err != nil {
 		err := fmt.Errorf("failed to run command. %w", err)
 		if !returnOutput {
@@ -115,7 +126,7 @@ func RunCommandInLabeledPod(ctx context.Context, clientsets *k8sutil.Clientsets,
 // have rook config files.
 func RunCommandInPod(ctx context.Context, clientsets *k8sutil.Clientsets, cmd string, args []string, podName, containerName, podNamespace string, returnOutput bool) (string, error) {
 	var stdout, stderr bytes.Buffer
-	err := execCmdInPod(ctx, clientsets, cmd, podName, containerName, podNamespace, "", args, &stdout, &stderr, returnOutput, true)
+	err := execCmdInPod(ctx, clientsets, cmd, podName, containerName, podNamespace, "", args, &stdout, &stderr, returnOutput, true, false)
 	if err != nil {
 		err = fmt.Errorf("%s. %w", stderr.String(), err)
 	}
@@ -129,7 +140,7 @@ func RunCommandInPod(ctx context.Context, clientsets *k8sutil.Clientsets, cmd st
 // execCmdInPod exec command on specific pod and wait the command's output.
 func execCmdInPod(ctx context.Context, clientsets *k8sutil.Clientsets,
 	command, podName, containerName, podNamespace, clusterNamespace string,
-	args []string, stdout, stderr io.Writer, returnOutput, skipConf bool) error {
+	args []string, stdout, stderr io.Writer, returnOutput, skipConf, tty bool) error {
 
 	if len(args) < 1 {
 		return fmt.Errorf("no arg passed to exec with %q command", command)
@@ -170,9 +181,10 @@ func execCmdInPod(ctx context.Context, clientsets *k8sutil.Clientsets,
 		VersionedParams(&v1.PodExecOptions{
 			Container: containerName,
 			Command:   cmd,
+			Stdin:     tty,
 			Stdout:    true,
 			Stderr:    true,
-			TTY:       false,
+			TTY:       tty,
 		}, scheme.ParameterCodec)
 
 	exec, err := remotecommand.NewSPDYExecutor(clientsets.KubeConfig, "POST", req.URL())
@@ -180,8 +192,26 @@ func execCmdInPod(ctx context.Context, clientsets *k8sutil.Clientsets,
 		return fmt.Errorf("failed to create SPDYExecutor. %w", err)
 	}
 
-	// returnOutput is true, the command's output will be print on shell directly with os.Stdout or os.Stderr
-	if !returnOutput {
+	if tty {
+		stdinFD := int(os.Stdin.Fd())
+		if !term.IsTerminal(stdinFD) {
+			return fmt.Errorf("stdin is not a terminal")
+		}
+		state, err := term.MakeRaw(stdinFD)
+		if err != nil {
+			return fmt.Errorf("failed to set terminal raw mode. %w", err)
+		}
+		defer func() {
+			_ = term.Restore(stdinFD, state)
+		}()
+
+		err = exec.StreamWithContext(ctx, remotecommand.StreamOptions{
+			Stdin:  os.Stdin,
+			Stdout: os.Stdout,
+			Stderr: os.Stderr,
+			Tty:    true,
+		})
+	} else if !returnOutput {
 		// Connect this process' std{in,out,err} to the remote shell process.
 		err = exec.StreamWithContext(ctx, remotecommand.StreamOptions{
 			Stdout: os.Stdout,


### PR DESCRIPTION
Added `kubectl rook-ceph fs-top` to run the interactive `cephfs-top` tool inside the rook operator pod. Injects connection args and streams a TTY so the curses UI works.

Resolves #442

How to test (quick)
- build: make build
- run: ./bin/kubectl-rook-ceph fs-top
- expected: `cephfs-top` interactive UI appears


<img width="853" height="371" alt="image" src="https://github.com/user-attachments/assets/95aaf7fe-eefc-4628-864b-4f6d395f5872" />


Checklist
- [x] Reviewed developer guide on submitting a PR
- [ ] Documentation updated if necessary
- [x] Commit Message Formatting
- [x] Unit tests added (small args helper test)
- [ ] Integration tests added (none)